### PR TITLE
Add PDVideoPlayerView container

### DIFF
--- a/Sources/PDVideoPlayer/PDVideoPlayer.swift
+++ b/Sources/PDVideoPlayer/PDVideoPlayer.swift
@@ -22,7 +22,7 @@ public struct PDVideoPlayer: View {
     @Environment(\.scenePhase) private var scenePhase
     public var body: some View {
         
-        PDVideoPlayerView(
+        PDVideoPlayerRepresentable(
             player: player,
             menuContent:{
                 Button{
@@ -61,7 +61,7 @@ public struct PDVideoPlayer: View {
         ZStack{
             Color.black
                 .ignoresSafeArea()
-            PDVideoPlayerView(model: playerViewModel)
+            PDVideoPlayerRepresentable(model: playerViewModel)
                 .rippleEffect(playerViewModel) { store in
                     playerViewModel.rippleStore = store
                 }

--- a/Sources/PDVideoPlayer/PDVideoPlayerView.swift
+++ b/Sources/PDVideoPlayer/PDVideoPlayerView.swift
@@ -1,0 +1,128 @@
+import SwiftUI
+import AVKit
+
+/// A container view that provides video player components.
+public struct PDVideoPlayerView<MenuContent: View, Content: View>: View {
+
+    @State private var model: PDPlayerModel
+
+    private var isMuted: Binding<Bool>?
+    private var isLongpress: Binding<Bool>?
+    private var controlsVisible: Binding<Bool>?
+    private var originalRate: Binding<Float>?
+    private var closeAction: VideoPlayerCloseAction?
+
+    private let menuContent: () -> MenuContent
+    private let content: (Proxy) -> Content
+
+    /// Proxy that exposes player and control views.
+    public struct Proxy {
+        public let player: PDVideoPlayerRepresentable
+        public let control: VideoPlayerControlView<MenuContent>
+    }
+
+    init(model: PDPlayerModel,
+         isMuted: Binding<Bool>? = nil,
+         isLongpress: Binding<Bool>? = nil,
+         controlsVisible: Binding<Bool>? = nil,
+         originalRate: Binding<Float>? = nil,
+         closeAction: VideoPlayerCloseAction? = nil,
+         @ViewBuilder menuContent: @escaping () -> MenuContent,
+         @ViewBuilder content: @escaping (Proxy) -> Content) {
+        self._model = State(initialValue: model)
+        self.isMuted = isMuted
+        self.isLongpress = isLongpress
+        self.controlsVisible = controlsVisible
+        self.originalRate = originalRate
+        self.closeAction = closeAction
+        self.menuContent = menuContent
+        self.content = content
+    }
+
+    /// Creates a player from a URL.
+    public init(url: URL,
+                @ViewBuilder menuContent: @escaping () -> MenuContent,
+                @ViewBuilder content: @escaping (Proxy) -> Content) {
+        self.init(model: PDPlayerModel(url: url),
+                  menuContent: menuContent,
+                  content: content)
+    }
+
+    /// Creates a player from an existing AVPlayer instance.
+    public init(player: AVPlayer,
+                @ViewBuilder menuContent: @escaping () -> MenuContent,
+                @ViewBuilder content: @escaping (Proxy) -> Content) {
+        self.init(model: PDPlayerModel(player: player),
+                  menuContent: menuContent,
+                  content: content)
+    }
+
+    public var body: some View {
+        let proxy = Proxy(
+            player: PDVideoPlayerRepresentable(model: model)
+                .rippleEffect(model) { store in
+                    model.rippleStore = store
+                },
+            control: VideoPlayerControlView(model: model, menuContent: menuContent)
+        )
+
+        return content(proxy)
+            .environment(\.videoPlayerIsMuted, isMuted)
+            .environment(\.videoPlayerIsLongpress, isLongpress)
+            .environment(\.videoPlayerControlsVisible, controlsVisible)
+            .environment(\.videoPlayerOriginalRate, originalRate)
+            .environment(\.videoPlayerCloseAction, closeAction)
+    }
+}
+
+public extension PDVideoPlayerView where MenuContent == EmptyView {
+    /// Convenience initializer when no menu content is provided.
+    init(url: URL,
+         @ViewBuilder content: @escaping (Proxy) -> Content) {
+        self.init(url: url, menuContent: { EmptyView() }, content: content)
+    }
+
+    /// Convenience initializer when no menu content is provided.
+    init(player: AVPlayer,
+         @ViewBuilder content: @escaping (Proxy) -> Content) {
+        self.init(player: player, menuContent: { EmptyView() }, content: content)
+    }
+}
+
+public extension PDVideoPlayerView {
+    /// Sets a binding for the muted state.
+    func isMuted(_ binding: Binding<Bool>) -> Self {
+        var copy = self
+        copy.isMuted = binding
+        return copy
+    }
+
+    /// Sets a binding for the long‑press state.
+    func isLongpress(_ binding: Binding<Bool>) -> Self {
+        var copy = self
+        copy.isLongpress = binding
+        return copy
+    }
+
+    /// Sets a binding for control visibility.
+    func controlsVisible(_ binding: Binding<Bool>) -> Self {
+        var copy = self
+        copy.controlsVisible = binding
+        return copy
+    }
+
+    /// Sets a binding for the original playback rate.
+    func originalRate(_ binding: Binding<Float>) -> Self {
+        var copy = self
+        copy.originalRate = binding
+        return copy
+    }
+
+    /// Sets a close action for the player.
+    func closeAction(_ action: VideoPlayerCloseAction) -> Self {
+        var copy = self
+        copy.closeAction = action
+        return copy
+    }
+}
+

--- a/Sources/PDVideoPlayer/Player/VideoPlayerViewControllerRepresentable.swift
+++ b/Sources/PDVideoPlayer/Player/VideoPlayerViewControllerRepresentable.swift
@@ -13,7 +13,7 @@ import AVKit
 
 #if os(macOS)
 
-public typealias PDVideoPlayerView = PDVideoPlayerView_macOS
+public typealias PDVideoPlayerRepresentable = PDVideoPlayerView_macOS
 
 public struct PDVideoPlayerView_macOS<MenuContent: View>: NSViewRepresentable {
     public typealias ContextMenuProvider = (CGPoint) -> NSMenu?
@@ -147,7 +147,7 @@ public class PlayerNSView: NSView {
 }
 
 #else
-public typealias PDVideoPlayerView = PDVideoPlayerView_iOS
+public typealias PDVideoPlayerRepresentable = PDVideoPlayerView_iOS
 public struct PDVideoPlayerView_iOS: UIViewRepresentable {
     public typealias ContextMenuProvider = (CGPoint) -> UIMenu?
     public typealias ScrollViewConfigurator = (UIScrollView) -> Void
@@ -268,9 +268,9 @@ public struct PDVideoPlayerView_iOS: UIViewRepresentable {
     }
 
     public class Coordinator: NSObject, UIScrollViewDelegate {
-        var parent: PDVideoPlayerView
+        var parent: PDVideoPlayerRepresentable
         weak var playerView:AVPlayerViewController?
-        init(_ parent: PDVideoPlayerView) {
+        init(_ parent: PDVideoPlayerRepresentable) {
             self.parent = parent
         }
         
@@ -353,7 +353,7 @@ class PlayerUIView: UIView,UIGestureRecognizerDelegate {
     }
     
 }
-extension PDVideoPlayerView.Coordinator: UIGestureRecognizerDelegate {
+extension PDVideoPlayerRepresentable.Coordinator: UIGestureRecognizerDelegate {
     public func gestureRecognizer(
         _ gestureRecognizer: UIGestureRecognizer,
         shouldReceive touch: UITouch
@@ -381,7 +381,7 @@ extension PDVideoPlayerView.Coordinator: UIGestureRecognizerDelegate {
     }
 }
 private let ADJSUT_GESTURE_INSET :CGFloat = 150
-extension PDVideoPlayerView.Coordinator: UIContextMenuInteractionDelegate {
+extension PDVideoPlayerRepresentable.Coordinator: UIContextMenuInteractionDelegate {
     
     public func contextMenuInteraction(
         _ interaction: UIContextMenuInteraction,
@@ -420,7 +420,7 @@ extension PDVideoPlayerView.Coordinator: UIContextMenuInteractionDelegate {
         }
     }
 }
-extension PDVideoPlayerView.Coordinator: UIPointerInteractionDelegate {
+extension PDVideoPlayerRepresentable.Coordinator: UIPointerInteractionDelegate {
     public func pointerInteraction(
         _ interaction: UIPointerInteraction,
         regionFor request: UIPointerRegionRequest,


### PR DESCRIPTION
## Summary
- rename platform representable type
- add new `PDVideoPlayerView` container for composing player and control views
- update references to new representable type

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*