### PR TITLE
Add closure overload for closeAction

### DIFF
--- a/Sources/PDVideoPlayer/PDVideoPlayer.swift
+++ b/Sources/PDVideoPlayer/PDVideoPlayer.swift
@@ -131,5 +131,12 @@ public extension PDVideoPlayer {
         copy.closeAction = action
         return copy
     }
+
+    /// Convenience overload to set a close action using a simple closure.
+    func closeAction(_ action: @escaping () -> Void) -> Self {
+        var copy = self
+        copy.closeAction = VideoPlayerCloseAction(action)
+        return copy
+    }
 }
 


### PR DESCRIPTION
## Summary
- add a convenience `closeAction` overload that accepts a simple closure

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*