### PR TITLE
Integrate longpress into player model

### DIFF
--- a/Sources/PDVideoPlayer/PDVideoPlayer.swift
+++ b/Sources/PDVideoPlayer/PDVideoPlayer.swift
@@ -14,10 +14,10 @@ public struct PDVideoPlayer<MenuContent: View, Content: View>: View {
     private var player: AVPlayer?
 
     private var isMuted: Binding<Bool>?
-    private var isLongpress: Binding<Bool>?
     private var controlsVisible: Binding<Bool>?
     private var originalRate: Binding<Float>?
     private var closeAction: VideoPlayerCloseAction?
+    private var longpressAction: VideoPlayerLongpressAction?
 
     private let content: (PDVideoPlayerProxy<MenuContent>) -> Content
     private let menuContent: () -> MenuContent
@@ -59,10 +59,10 @@ public struct PDVideoPlayer<MenuContent: View, Content: View>: View {
                 content(proxy)
                     .environment(model)
                     .environment(\.videoPlayerIsMuted, isMuted)
-                    .environment(\.videoPlayerIsLongpress, isLongpress)
                     .environment(\.videoPlayerControlsVisible, controlsVisible)
                     .environment(\.videoPlayerOriginalRate, originalRate)
                     .environment(\.videoPlayerCloseAction, closeAction)
+                    .environment(\.videoPlayerLongpressAction, longpressAction)
             }
         }
         .task(id: url) {
@@ -104,13 +104,6 @@ public extension PDVideoPlayer {
         return copy
     }
 
-    /// Sets a binding for the long‑press state.
-    func isLongpress(_ binding: Binding<Bool>) -> Self {
-        var copy = self
-        copy.isLongpress = binding
-        return copy
-    }
-
     /// Sets a binding for control visibility.
     func controlsVisible(_ binding: Binding<Bool>) -> Self {
         var copy = self
@@ -136,6 +129,20 @@ public extension PDVideoPlayer {
     func closeAction(_ action: @escaping () -> Void) -> Self {
         var copy = self
         copy.closeAction = VideoPlayerCloseAction(action)
+        return copy
+    }
+
+    /// Sets an action triggered when long‑press state changes.
+    func longpressAction(_ action: VideoPlayerLongpressAction) -> Self {
+        var copy = self
+        copy.longpressAction = action
+        return copy
+    }
+
+    /// Convenience overload to set a long‑press action using a simple closure.
+    func longpressAction(_ action: @escaping (Bool) -> Void) -> Self {
+        var copy = self
+        copy.longpressAction = VideoPlayerLongpressAction(action)
         return copy
     }
 }

--- a/Sources/PDVideoPlayer/PDVideoPlayerSampleView.swift
+++ b/Sources/PDVideoPlayer/PDVideoPlayerSampleView.swift
@@ -42,9 +42,9 @@ private let videoURL = URL(fileURLWithPath: "/Users/kn/Downloads/ScreenRecording
 
 private struct ContentView: View {
     @State private var isMuted: Bool = true
-    @State private var isLongpress: Bool = false
     @State private var controlsVisible: Bool = true
     @State private var originalRate: Float = 1.0
+    @State private var isLongpress: Bool = false
 
     var body:some View{
         PDVideoPlayer(
@@ -67,9 +67,11 @@ private struct ContentView: View {
             }
         )
         .isMuted($isMuted)
-        .isLongpress($isLongpress)
         .controlsVisible($controlsVisible)
         .originalRate($originalRate)
+        .longpressAction { value in
+            isLongpress = value
+        }
         .closeAction {
             
         }

--- a/Sources/PDVideoPlayer/Player/PDPlayerModel.swift
+++ b/Sources/PDVideoPlayer/Player/PDPlayerModel.swift
@@ -109,7 +109,7 @@ enum SkipDirection {
     
     private var timeObserverToken: Any?
     private var playerVC:AVPlayerViewController?
-    @ObservationIgnored var isLongpress:Bool = false
+    public var isLongpress:Bool = false
     public init(
         url: URL
     ) {

--- a/Sources/PDVideoPlayer/Player/VideoPlayerViewControllerRepresentable.swift
+++ b/Sources/PDVideoPlayer/Player/VideoPlayerViewControllerRepresentable.swift
@@ -170,9 +170,9 @@ public struct PDVideoPlayerView_iOS: UIViewRepresentable {
     }
     @Environment(\.videoPlayerCloseAction) private var closeAction
     @Environment(\.videoPlayerIsMuted) private var isMutedBinding
-    @Environment(\.videoPlayerIsLongpress) private var isLongpressBinding
     @Environment(\.videoPlayerControlsVisible) private var controlsVisibleBinding
     @Environment(\.videoPlayerOriginalRate) private var originalRateBinding
+    @Environment(\.videoPlayerLongpressAction) private var longpressAction
     @Environment(\.isPresentedMedia) private var isPresented
 
 
@@ -319,14 +319,14 @@ public struct PDVideoPlayerView_iOS: UIViewRepresentable {
                 if self.parent.model.isPlaying {
                     // 現在のレートの2倍にする
                     self.parent.model.player.rate = min((self.parent.originalRateBinding?.wrappedValue ?? 1.0) * 2.0,2.0)
-                    self.parent.isLongpressBinding?.wrappedValue = true
                     self.parent.model.isLongpress = true
+                    self.parent.longpressAction?(true)
                 }
             case .ended, .cancelled, .failed:
                 // 長押し終了時に元のレートに戻す
                 self.parent.model.player.rate = self.parent.originalRateBinding?.wrappedValue ?? self.parent.model.player.rate
-                self.parent.isLongpressBinding?.wrappedValue = false
                 self.parent.model.isLongpress = false
+                self.parent.longpressAction?(false)
             default:
                 break
             }

--- a/Sources/PDVideoPlayer/VideoPlayerEnvironment.swift
+++ b/Sources/PDVideoPlayer/VideoPlayerEnvironment.swift
@@ -17,14 +17,25 @@ private struct VideoPlayerCloseActionKey: @preconcurrency EnvironmentKey {
 private struct VideoPlayerIsMutedKey: EnvironmentKey {
     static let defaultValue: Binding<Bool>? = nil
 }
-private struct VideoPlayerIsLongpressKey: EnvironmentKey {
-    static let defaultValue: Binding<Bool>? = nil
-}
 private struct VideoPlayerControlsVisibleKey: EnvironmentKey {
     static let defaultValue: Binding<Bool>? = nil
 }
 private struct VideoPlayerOriginalRateKey: EnvironmentKey {
     static let defaultValue: Binding<Float>? = nil
+}
+
+public struct VideoPlayerLongpressAction {
+    let action: (Bool) -> Void
+    public init(_ action: @escaping (Bool) -> Void) {
+        self.action = action
+    }
+    public func callAsFunction(_ value: Bool) {
+        action(value)
+    }
+}
+
+private struct VideoPlayerLongpressActionKey: EnvironmentKey {
+    static let defaultValue: VideoPlayerLongpressAction? = nil
 }
 
 public extension EnvironmentValues {
@@ -36,10 +47,6 @@ public extension EnvironmentValues {
         get { self[VideoPlayerIsMutedKey.self] }
         set { self[VideoPlayerIsMutedKey.self] = newValue }
     }
-    var videoPlayerIsLongpress: Binding<Bool>? {
-        get { self[VideoPlayerIsLongpressKey.self] }
-        set { self[VideoPlayerIsLongpressKey.self] = newValue }
-    }
     var videoPlayerControlsVisible: Binding<Bool>? {
         get { self[VideoPlayerControlsVisibleKey.self] }
         set { self[VideoPlayerControlsVisibleKey.self] = newValue }
@@ -47,5 +54,9 @@ public extension EnvironmentValues {
     var videoPlayerOriginalRate: Binding<Float>? {
         get { self[VideoPlayerOriginalRateKey.self] }
         set { self[VideoPlayerOriginalRateKey.self] = newValue }
+    }
+    var videoPlayerLongpressAction: VideoPlayerLongpressAction? {
+        get { self[VideoPlayerLongpressActionKey.self] }
+        set { self[VideoPlayerLongpressActionKey.self] = newValue }
     }
 }

--- a/Sources/PDVideoPlayer/VideoPlayerNavigationView.swift
+++ b/Sources/PDVideoPlayer/VideoPlayerNavigationView.swift
@@ -12,9 +12,10 @@ public struct VideoPlayerNavigationView:View{
 
     @Environment(\.videoPlayerCloseAction) private var closeAction
     @Environment(\.videoPlayerIsMuted) private var isMutedBinding
-    @Environment(\.videoPlayerIsLongpress) private var isLongpressBinding
     @Environment(\.videoPlayerControlsVisible) private var controlsVisibleBinding
     @Environment(\.videoPlayerOriginalRate) private var originalRateBinding
+    @Environment(PDPlayerModel.self) private var model
+    @Environment(\.videoPlayerLongpressAction) private var longpressAction
     public var body:some View{
         VStack {
             ZStack{
@@ -51,13 +52,16 @@ public struct VideoPlayerNavigationView:View{
             .frame(height:44)
             .padding(.horizontal,12)
            
-            if isLongpressBinding?.wrappedValue ?? false{
+            if model.isLongpress{
                 fastView()
                     .transition(.opacity)
             }
         }
-        .animation(.smooth(duration:0.12),value:isLongpressBinding?.wrappedValue)
+        .animation(.smooth(duration:0.12),value:model.isLongpress)
         .animation(.smooth(duration:0.12),value:controlsVisibleBinding?.wrappedValue)
+        .onChange(of: model.isLongpress) { newValue in
+            longpressAction?(newValue)
+        }
         
     }
     private func fastView() -> some View {


### PR DESCRIPTION
## Summary
- remove `videoPlayerIsLongpress` environment value
- add `VideoPlayerLongpressAction` for long‑press callbacks
- keep long‑press state inside `PDPlayerModel`
- pass the callback through `PDVideoPlayer`
- update sample view and navigation view to use new mechanism

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*