### PR TITLE
Add navigation view proxy

### DIFF
--- a/Sources/PDVideoPlayer/PDVideoPlayer.swift
+++ b/Sources/PDVideoPlayer/PDVideoPlayer.swift
@@ -4,6 +4,7 @@ import AVKit
 public struct PDVideoPlayerProxy<MenuContent: View> {
     public let player:  PDVideoPlayerRepresentable
     public let control: VideoPlayerControlView<MenuContent>
+    public let navigation: VideoPlayerNavigationView
 }
 /// A container view that provides video player components.
 public struct PDVideoPlayer<MenuContent: View, Content: View>: View {
@@ -53,7 +54,8 @@ public struct PDVideoPlayer<MenuContent: View, Content: View>: View {
             if let model {
                 let proxy = PDVideoPlayerProxy(
                     player: PDVideoPlayerRepresentable(model: model),
-                    control: VideoPlayerControlView(model: model, menuContent: menuContent)
+                    control: VideoPlayerControlView(model: model, menuContent: menuContent),
+                    navigation: VideoPlayerNavigationView()
                 )
 
                 content(proxy)

--- a/Sources/PDVideoPlayer/PDVideoPlayerSampleView.swift
+++ b/Sources/PDVideoPlayer/PDVideoPlayerSampleView.swift
@@ -62,6 +62,10 @@ private struct ContentView: View {
                         .rippleEffect()
                         .ignoresSafeArea()
                     proxy.control
+                    VStack {
+                        proxy.navigation
+                        Spacer()
+                    }
                 }
             }
         )


### PR DESCRIPTION
## Summary
- expose `VideoPlayerNavigationView` via `PDVideoPlayerProxy`
- construct proxy with navigation view
- update sample view to show the navigation view

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*
- `swift test` *(fails: no such module 'SwiftUI')*