### PR TITLE
Modify close action API

### DIFF
--- a/Sources/PDVideoPlayer/PDVideoPlayer.swift
+++ b/Sources/PDVideoPlayer/PDVideoPlayer.swift
@@ -132,7 +132,7 @@ public extension PDVideoPlayer {
     }
 
     /// Convenience overload to set a close action using a simple closure.
-    func closeAction(_ action: @escaping () -> Void) -> Self {
+    func closeAction(_ action: @escaping (CGFloat) -> Void) -> Self {
         var copy = self
         copy.closeAction = VideoPlayerCloseAction(action)
         return copy

--- a/Sources/PDVideoPlayer/PDVideoPlayerSampleView.swift
+++ b/Sources/PDVideoPlayer/PDVideoPlayerSampleView.swift
@@ -89,8 +89,8 @@ private struct ContentView: View {
         .longpressAction { value in
             print("longpressAction",value)
         }
-        .closeAction {
-            
+        .closeAction { _ in
+
         }
     }
 }

--- a/Sources/PDVideoPlayer/Player/PDPlayerModel.swift
+++ b/Sources/PDVideoPlayer/Player/PDPlayerModel.swift
@@ -17,7 +17,7 @@ enum SkipDirection {
     case forward
 }
 @MainActor
-@Observable public class PDPlayerModel: NSObject {
+@Observable public class PDPlayerModel: NSObject, DynamicProperty {
     public var isPlaying: Bool = false
     public var currentTime: Double = 0
     public var duration: Double = 0
@@ -31,7 +31,7 @@ enum SkipDirection {
     @ObservationIgnored private var cancellables = Set<AnyCancellable>()
     
     public var player: AVPlayer
-    public var onCloseAction: ((CGFloat) -> Void)? = nil
+    @Environment(\.videoPlayerCloseAction) private var closeAction
     
     var doubleTapCount: Int = 0
     private var doubleTapBaseTime: Double = 0
@@ -40,6 +40,7 @@ enum SkipDirection {
     private var doubleTapDirection: SkipDirection? = nil
     let rippleStore = RippleEffectStore()
     public var scrollView = UIScrollView()
+    public func update() {}
     @objc func handleDoubleTap(_ recognizer: UITapGestureRecognizer) {
         // タップ位置でリップルエフェクトだけ先に発火
         let location = recognizer.location(in: recognizer.view)
@@ -283,7 +284,7 @@ extension PDPlayerModel:UIGestureRecognizerDelegate{
                 } else if stoptime < 0.2 {
                     stoptime = 0.2
                 }
-                onCloseAction?(stoptime * 0.5)
+                closeAction?(stoptime * 0.5)
                
                 UIView.animate(withDuration: stoptime, delay: 0, options: .curveLinear, animations: {
                     containerView.center = CGPoint(
@@ -340,7 +341,7 @@ extension PDPlayerModel:UIGestureRecognizerDelegate{
                 } else if stoptime < 0.18{
                     stoptime = 0.15
                 }
-                onCloseAction?(stoptime * 0.5)
+                closeAction?(stoptime * 0.5)
            
                 UIView.animate(withDuration: stoptime, delay: 0, options: .curveLinear, animations: {
                     containerView.center = CGPoint(

--- a/Sources/PDVideoPlayer/Player/VideoPlayerViewControllerRepresentable.swift
+++ b/Sources/PDVideoPlayer/Player/VideoPlayerViewControllerRepresentable.swift
@@ -305,7 +305,7 @@ public struct PDVideoPlayerView_iOS: UIViewRepresentable {
                     binding.wrappedValue.toggle()
                 }
             } else {
-                parent.closeAction?()
+                parent.closeAction?(0)
             }
         }
         @objc func handleLongPress(_ recognizer: UILongPressGestureRecognizer) {

--- a/Sources/PDVideoPlayer/VideoPlayerEnvironment.swift
+++ b/Sources/PDVideoPlayer/VideoPlayerEnvironment.swift
@@ -2,12 +2,12 @@ import SwiftUI
 
 /// Closure wrapper that can be invoked like a function.
 public struct VideoPlayerCloseAction {
-    let action: () -> Void
-    public init(_ action: @escaping () -> Void) {
+    let action: (CGFloat) -> Void
+    public init(_ action: @escaping (CGFloat) -> Void) {
         self.action = action
     }
-    public func callAsFunction() {
-        action()
+    public func callAsFunction(_ duration: CGFloat) {
+        action(duration)
     }
 }
 

--- a/Sources/PDVideoPlayer/VideoPlayerNavigationView.swift
+++ b/Sources/PDVideoPlayer/VideoPlayerNavigationView.swift
@@ -23,7 +23,7 @@ public struct VideoPlayerNavigationView:View{
                     HStack(spacing:4){
                         if UIDevice.current.userInterfaceIdiom == .pad{
                             Button {
-                                closeAction?()
+                                closeAction?(0)
                             } label: {
                                 ZStack{
                                     Color.clear


### PR DESCRIPTION
## Summary
- update `VideoPlayerCloseAction` to accept a `CGFloat` duration
- adjust player builder to accept the new closure signature
- remove `onCloseAction` from `PDPlayerModel` and use environment close action
- update call sites to pass a duration value

## Testing
- `swift test -v` *(fails: no such module 'SwiftUI')*