### PR TITLE
Propagate close action via model

### DIFF
--- a/Sources/PDVideoPlayer/PDVideoPlayer.swift
+++ b/Sources/PDVideoPlayer/PDVideoPlayer.swift
@@ -69,16 +69,26 @@ public struct PDVideoPlayer<MenuContent: View, Content: View>: View {
                     .environment(\.videoPlayerOriginalRate, originalRate)
                     .environment(\.videoPlayerCloseAction, closeAction)
                     .environment(\.videoPlayerLongpressAction, longpressAction)
+                    .onAppear {
+                        model.closeAction = closeAction
+                    }
+                    .onChange(of: closeAction) { newValue in
+                        model.closeAction = newValue
+                    }
             }
         }
         .task(id: url) {
             if let url {
-                model = PDPlayerModel(url: url)
+                var newModel = PDPlayerModel(url: url)
+                newModel.closeAction = closeAction
+                model = newModel
             }
         }
         .task(id: playerID) {
             if let player {
-                model = PDPlayerModel(player: player)
+                var newModel = PDPlayerModel(player: player)
+                newModel.closeAction = closeAction
+                model = newModel
             }
         }
     }

--- a/Sources/PDVideoPlayer/Player/PDPlayerModel.swift
+++ b/Sources/PDVideoPlayer/Player/PDPlayerModel.swift
@@ -31,7 +31,7 @@ enum SkipDirection {
     @ObservationIgnored private var cancellables = Set<AnyCancellable>()
     
     public var player: AVPlayer
-    @Environment(\.videoPlayerCloseAction) private var closeAction
+    public var closeAction: VideoPlayerCloseAction?
     
     var doubleTapCount: Int = 0
     private var doubleTapBaseTime: Double = 0


### PR DESCRIPTION
## Summary
- propagate close action from the `PDVideoPlayer` view down to `PDPlayerModel`
- store close action in `PDPlayerModel` rather than injecting it with `@Environment`

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*