### PR TITLE
Add configurable pan gesture for player

### DIFF
--- a/Sources/PDVideoPlayer/PDVideoPlayer.swift
+++ b/Sources/PDVideoPlayer/PDVideoPlayer.swift
@@ -22,6 +22,7 @@ public struct PDVideoPlayer<MenuContent: View, Content: View>: View {
 #if os(iOS)
     private var scrollViewConfigurator: PDVideoPlayerRepresentable.ScrollViewConfigurator?
     private var contextMenuProvider: PDVideoPlayerRepresentable.ContextMenuProvider?
+    private var panGesture: PDVideoPlayerPanGesture = .rotation
 #endif
 
     private let content: (PDVideoPlayerProxy<MenuContent>) -> Content
@@ -57,7 +58,12 @@ public struct PDVideoPlayer<MenuContent: View, Content: View>: View {
         ZStack {
             if let model {
                 let proxy = PDVideoPlayerProxy(
-                    player: PDVideoPlayerRepresentable(model: model),
+                    player: PDVideoPlayerRepresentable(
+                        model: model,
+                        panGesture: panGesture,
+                        scrollViewConfigurator: scrollViewConfigurator,
+                        contextMenuProvider: contextMenuProvider
+                    ),
                     control: VideoPlayerControlView(model: model, menuContent: menuContent),
                     navigation: VideoPlayerNavigationView()
                 )
@@ -174,6 +180,13 @@ public extension PDVideoPlayer {
     func contextMenuProvider(_ provider: @escaping PDVideoPlayerRepresentable.ContextMenuProvider) -> Self {
         var copy = self
         copy.contextMenuProvider = provider
+        return copy
+    }
+
+    /// Sets the pan gesture style used for dismissing the video.
+    func panGesture(_ gesture: PDVideoPlayerPanGesture) -> Self {
+        var copy = self
+        copy.panGesture = gesture
         return copy
     }
 #endif

--- a/Sources/PDVideoPlayer/Player/PDVideoPlayerPanGesture.swift
+++ b/Sources/PDVideoPlayer/Player/PDVideoPlayerPanGesture.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+#if os(iOS)
+/// Gesture types for closing the player.
+public enum PDVideoPlayerPanGesture {
+    /// Drag with rotation gesture.
+    case rotation
+    /// Drag only up and down.
+    case vertical
+    /// Disable pan gesture.
+    case none
+}
+#endif

--- a/Sources/PDVideoPlayer/Player/PDVideoPlayerProxy+Extensions.swift
+++ b/Sources/PDVideoPlayer/Player/PDVideoPlayerProxy+Extensions.swift
@@ -4,10 +4,14 @@ import SwiftUI
 @MainActor
 extension PDVideoPlayerProxy {
     func player(
+        panGesture: PDVideoPlayerPanGesture? = nil,
         scrollViewConfigurator: PDVideoPlayerRepresentable.ScrollViewConfigurator? = nil,
         contextMenuProvider: PDVideoPlayerRepresentable.ContextMenuProvider? = nil
     ) -> PDVideoPlayerRepresentable {
         var view = self.player
+        if let panGesture {
+            view = view.panGesture(panGesture)
+        }
         if let scrollViewConfigurator {
             view = view.scrollViewConfigurator(scrollViewConfigurator)
         }

--- a/Sources/PDVideoPlayer/Player/PDVideoPlayerRepresentable+Extensions.swift
+++ b/Sources/PDVideoPlayer/Player/PDVideoPlayerRepresentable+Extensions.swift
@@ -3,11 +3,15 @@ import SwiftUI
 
 extension PDVideoPlayerRepresentable {
     func scrollViewConfigurator(_ configurator: @escaping ScrollViewConfigurator) -> Self {
-        Self(model: self.model, scrollViewConfigurator: configurator, contextMenuProvider: self.contextMenuProvider)
+        Self(model: self.model, panGesture: self.panGesture, scrollViewConfigurator: configurator, contextMenuProvider: self.contextMenuProvider)
     }
 
     func contextMenuProvider(_ provider: @escaping ContextMenuProvider) -> Self {
-        Self(model: self.model, scrollViewConfigurator: self.scrollViewConfigurator, contextMenuProvider: provider)
+        Self(model: self.model, panGesture: self.panGesture, scrollViewConfigurator: self.scrollViewConfigurator, contextMenuProvider: provider)
+    }
+
+    func panGesture(_ gesture: PDVideoPlayerPanGesture) -> Self {
+        Self(model: self.model, panGesture: gesture, scrollViewConfigurator: self.scrollViewConfigurator, contextMenuProvider: self.contextMenuProvider)
     }
 }
 #endif

--- a/Sources/PDVideoPlayer/Player/VideoPlayerViewControllerRepresentable.swift
+++ b/Sources/PDVideoPlayer/Player/VideoPlayerViewControllerRepresentable.swift
@@ -154,19 +154,22 @@ public struct PDVideoPlayerView_iOS: UIViewRepresentable {
 
     
     var model: PDPlayerModel
+    let panGesture: PDVideoPlayerPanGesture
     let scrollViewConfigurator: ScrollViewConfigurator?
     let contextMenuProvider: ContextMenuProvider?
  
     public init(
-        model:PDPlayerModel,
+        model: PDPlayerModel,
+        panGesture: PDVideoPlayerPanGesture = .rotation,
         scrollViewConfigurator: ScrollViewConfigurator? = nil,
         contextMenuProvider: ContextMenuProvider? = nil
-       
-    ){
+
+    ) {
         self.model = model
+        self.panGesture = panGesture
         self.scrollViewConfigurator = scrollViewConfigurator
         self.contextMenuProvider = contextMenuProvider
-     
+
     }
     @Environment(\.videoPlayerCloseAction) private var closeAction
     @Environment(\.videoPlayerIsMuted) private var isMutedBinding
@@ -255,6 +258,20 @@ public struct PDVideoPlayerView_iOS: UIViewRepresentable {
         if contextMenuProvider != nil{
             let contextMenuInteraction = UIContextMenuInteraction(delegate: context.coordinator)
             playerView.view.addInteraction(contextMenuInteraction)
+        }
+        switch panGesture {
+        case .rotation:
+            let panGestureRecognizer = UIPanGestureRecognizer(target: model, action: #selector(PDPlayerModel.handlePanGesture(_:)))
+            panGestureRecognizer.delegate = model
+            scrollView.isUserInteractionEnabled = true
+            scrollView.addGestureRecognizer(panGestureRecognizer)
+        case .vertical:
+            let panGestureRecognizer = UIPanGestureRecognizer(target: model, action: #selector(PDPlayerModel.handlePanGestureUpDown(_:)))
+            panGestureRecognizer.delegate = model
+            scrollView.isUserInteractionEnabled = true
+            scrollView.addGestureRecognizer(panGestureRecognizer)
+        case .none:
+            break
         }
         scrollViewConfigurator?(scrollView)
 


### PR DESCRIPTION
## Summary
- add `PDVideoPlayerPanGesture` enum to select drag behavior
- allow `PDVideoPlayerView_iOS` to install appropriate pan gesture
- expose `panGesture` modifier on `PDVideoPlayer`
- propagate option via proxy helpers

## Testing
- `swift test -l` *(fails: no such module 'SwiftUI')*