### PR TITLE
Add macOS PDVideoPlayer

### DIFF
--- a/Sources/PDVideoPlayer/PDVideoPlayer+macOS.swift
+++ b/Sources/PDVideoPlayer/PDVideoPlayer+macOS.swift
@@ -1,0 +1,47 @@
+#if os(macOS)
+import SwiftUI
+import AVKit
+
+/// A lightweight container for playing videos on macOS.
+public struct PDVideoPlayer<MenuContent: View>: View {
+    private var player: AVPlayer
+    private let menuContent: () -> MenuContent
+
+    /// Creates a player from a URL.
+    public init(
+        url: URL,
+        @ViewBuilder menuContent: @escaping () -> MenuContent
+    ) {
+        self.player = AVPlayer(url: url)
+        self.menuContent = menuContent
+    }
+
+    /// Creates a player from an existing AVPlayer instance.
+    public init(
+        player: AVPlayer,
+        @ViewBuilder menuContent: @escaping () -> MenuContent
+    ) {
+        self.player = player
+        self.menuContent = menuContent
+    }
+
+    public var body: some View {
+        PDVideoPlayerRepresentable(
+            player: player,
+            menuContent: menuContent
+        )
+    }
+}
+
+public extension PDVideoPlayer where MenuContent == EmptyView {
+    /// Convenience initializer when no menu content is provided.
+    init(url: URL) {
+        self.init(url: url, menuContent: { EmptyView() })
+    }
+
+    /// Convenience initializer when no menu content is provided.
+    init(player: AVPlayer) {
+        self.init(player: player, menuContent: { EmptyView() })
+    }
+}
+#endif

--- a/Sources/PDVideoPlayer/PDVideoPlayer.swift
+++ b/Sources/PDVideoPlayer/PDVideoPlayer.swift
@@ -1,3 +1,4 @@
+#if os(iOS)
 import SwiftUI
 import AVKit
 
@@ -19,9 +20,7 @@ public struct PDVideoPlayer<MenuContent: View, Content: View>: View {
     private var originalRate: Binding<Float>?
     private var closeAction: VideoPlayerCloseAction?
     private var longpressAction: VideoPlayerLongpressAction?
-#if os(iOS)
     private var panGesture: PDVideoPlayerPanGesture = .rotation
-#endif
 
     private let content: (PDVideoPlayerProxy<MenuContent>) -> Content
     private let menuContent: () -> MenuContent
@@ -157,12 +156,11 @@ public extension PDVideoPlayer {
         copy.longpressAction = VideoPlayerLongpressAction(action)
         return copy
     }
-#if os(iOS)
     /// Sets the pan gesture style used for dismissing the video.
     func panGesture(_ gesture: PDVideoPlayerPanGesture) -> Self {
         var copy = self
         copy.panGesture = gesture
         return copy
     }
-#endif
 }
+#endif


### PR DESCRIPTION
## Summary
- wrap iOS-only PDVideoPlayer implementation in a conditional
- add a simplified macOS variant that accepts a URL or AVPlayer

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*