### PR TITLE
Add macOS slider customization

### DIFF
--- a/Sources/PDVideoPlayer/PDVideoPlayer+macOS.swift
+++ b/Sources/PDVideoPlayer/PDVideoPlayer+macOS.swift
@@ -2,46 +2,149 @@
 import SwiftUI
 import AVKit
 
-/// A lightweight container for playing videos on macOS.
-public struct PDVideoPlayer<MenuContent: View>: View {
-    private var player: AVPlayer
+public struct PDVideoPlayerProxy<MenuContent: View> {
+    public let player: PDVideoPlayerRepresentable
+    public let control: VideoPlayerControlView<MenuContent>
+    public let navigation: VideoPlayerNavigationView
+}
+
+public struct PDVideoPlayer<MenuContent: View, Content: View>: View {
+    @State private var model: PDPlayerModel? = nil
+
+    private var url: URL?
+    private var player: AVPlayer?
+
+    private var isMuted: Binding<Bool>?
+    private var controlsVisible: Binding<Bool>?
+    private var originalRate: Binding<Float>?
+    private var closeAction: VideoPlayerCloseAction?
+    private var longpressAction: VideoPlayerLongpressAction?
+
+    private let content: (PDVideoPlayerProxy<MenuContent>) -> Content
     private let menuContent: () -> MenuContent
 
-    /// Creates a player from a URL.
+    private var playerID: ObjectIdentifier? { player.map { ObjectIdentifier($0) } }
+
     public init(
         url: URL,
-        @ViewBuilder menuContent: @escaping () -> MenuContent
+        @ViewBuilder menuContent: @escaping () -> MenuContent,
+        @ViewBuilder content: @escaping (PDVideoPlayerProxy<MenuContent>) -> Content
     ) {
-        self.player = AVPlayer(url: url)
+        self.url = url
         self.menuContent = menuContent
+        self.content = content
     }
 
-    /// Creates a player from an existing AVPlayer instance.
     public init(
         player: AVPlayer,
-        @ViewBuilder menuContent: @escaping () -> MenuContent
+        @ViewBuilder menuContent: @escaping () -> MenuContent,
+        @ViewBuilder content: @escaping (PDVideoPlayerProxy<MenuContent>) -> Content
     ) {
         self.player = player
         self.menuContent = menuContent
+        self.content = content
     }
 
     public var body: some View {
-        PDVideoPlayerRepresentable(
-            player: player,
-            menuContent: menuContent
-        )
+        ZStack {
+            if let model {
+                let proxy = PDVideoPlayerProxy(
+                    player: PDVideoPlayerRepresentable(
+                        player: model.player,
+                        playerViewConfigurator: { $0.controlsStyle = .none },
+                        menuContent: menuContent
+                    ),
+                    control: VideoPlayerControlView(model: model, menuContent: menuContent),
+                    navigation: VideoPlayerNavigationView()
+                )
+
+                content(proxy)
+                    .environment(model)
+                    .environment(\.videoPlayerIsMuted, isMuted)
+                    .environment(\.videoPlayerControlsVisible, controlsVisible)
+                    .environment(\.videoPlayerOriginalRate, originalRate)
+                    .environment(\.videoPlayerCloseAction, closeAction)
+                    .environment(\.videoPlayerLongpressAction, longpressAction)
+            }
+        }
+        .task(id: url) {
+            if let url {
+                let m = PDPlayerModel(url: url)
+                m.closeAction = closeAction
+                model = m
+            }
+        }
+        .task(id: playerID) {
+            if let player {
+                let m = PDPlayerModel(player: player)
+                m.closeAction = closeAction
+                model = m
+            }
+        }
     }
 }
 
 public extension PDVideoPlayer where MenuContent == EmptyView {
-    /// Convenience initializer when no menu content is provided.
-    init(url: URL) {
-        self.init(url: url, menuContent: { EmptyView() })
+    init(
+        url: URL,
+        @ViewBuilder content: @escaping (PDVideoPlayerProxy<MenuContent>) -> Content
+    ) {
+        self.init(url: url, menuContent: { EmptyView() }, content: content)
     }
 
-    /// Convenience initializer when no menu content is provided.
-    init(player: AVPlayer) {
-        self.init(player: player, menuContent: { EmptyView() })
+    init(
+        player: AVPlayer,
+        @ViewBuilder content: @escaping (PDVideoPlayerProxy<MenuContent>) -> Content
+    ) {
+        self.init(player: player, menuContent: { EmptyView() }, content: content)
+    }
+}
+
+public extension PDVideoPlayer {
+    func isMuted(_ binding: Binding<Bool>) -> Self {
+        var copy = self
+        copy.isMuted = binding
+        return copy
+    }
+
+    func controlsVisible(_ binding: Binding<Bool>) -> Self {
+        var copy = self
+        copy.controlsVisible = binding
+        return copy
+    }
+
+    func originalRate(_ binding: Binding<Float>) -> Self {
+        var copy = self
+        copy.originalRate = binding
+        return copy
+    }
+
+    func closeAction(_ action: VideoPlayerCloseAction) -> Self {
+        var copy = self
+        copy.closeAction = action
+        return copy
+    }
+
+    func closeAction(_ action: @escaping (CGFloat) -> Void) -> Self {
+        var copy = self
+        copy.closeAction = VideoPlayerCloseAction(action)
+        return copy
+    }
+
+    func longpressAction(_ action: VideoPlayerLongpressAction) -> Self {
+        var copy = self
+        copy.longpressAction = action
+        return copy
+    }
+
+    func longpressAction(_ action: @escaping (Bool) -> Void) -> Self {
+        var copy = self
+        copy.longpressAction = VideoPlayerLongpressAction(action)
+        return copy
+    }
+
+    func panGesture(_ gesture: PDVideoPlayerPanGesture) -> Self {
+        self
     }
 }
 #endif

--- a/Sources/PDVideoPlayer/Player/PDVideoPlayerRepresentable+Extensions-macOS.swift
+++ b/Sources/PDVideoPlayer/Player/PDVideoPlayerRepresentable+Extensions-macOS.swift
@@ -1,0 +1,13 @@
+#if os(macOS)
+import SwiftUI
+
+public extension PDVideoPlayerRepresentable {
+    func playerViewConfigurator(_ configurator: @escaping PlayerViewConfigurator) -> Self {
+        Self(player: self.player, playerViewConfigurator: configurator, resizeAction: self.resizeAction, menuContent: self.menuContent)
+    }
+
+    func resizeAction(_ action: @escaping ResizeAction) -> Self {
+        Self(player: self.player, playerViewConfigurator: self.playerViewConfigurator, resizeAction: action, menuContent: self.menuContent)
+    }
+}
+#endif

--- a/Sources/PDVideoPlayer/Slider/VideoPlayerSlider.swift
+++ b/Sources/PDVideoPlayer/Slider/VideoPlayerSlider.swift
@@ -8,6 +8,15 @@
 import SwiftUI
 import AVFoundation
 #if os(macOS)
+import AppKit
+
+class VideoPlayerSlider: NSSlider {
+    override var intrinsicContentSize: NSSize {
+        let size = super.intrinsicContentSize
+        return NSSize(width: size.width, height: size.height + 20)
+    }
+}
+
 #else
 class VideoPlayerSlider: UISlider {
 

--- a/Sources/PDVideoPlayer/VideoPlayerControlView.swift
+++ b/Sources/PDVideoPlayer/VideoPlayerControlView.swift
@@ -7,6 +7,49 @@
 
 import SwiftUI
 #if os(macOS)
+public struct VideoPlayerControlView<MenuContent: View>: View {
+    var model: PDPlayerModel
+    @Environment(\.videoPlayerControlsVisible) private var controlsVisibleBinding
+
+    private let menuContent: () -> MenuContent
+
+    public init(
+        model: PDPlayerModel,
+        @ViewBuilder menuContent: @escaping () -> MenuContent
+    ) {
+        self.model = model
+        self.menuContent = menuContent
+    }
+
+    public var body: some View {
+        ZStack {
+            if controlsVisibleBinding?.wrappedValue ?? true {
+                VStack {
+                    Spacer()
+                    VStack {
+                        HStack {
+                            Button { model.togglePlay() } label: {
+                                Image(systemName: model.isPlaying ? "pause.fill" : "play.fill")
+                                    .foregroundStyle(.white)
+                            }
+                            Spacer()
+                            Menu(content: menuContent) {
+                                Image(systemName: "ellipsis.circle")
+                                    .foregroundStyle(.white)
+                            }
+                        }
+                        .padding(.horizontal)
+
+                        VideoPlayerSliderView(viewModel: model)
+                            .padding(.horizontal)
+                    }
+                    .frame(maxWidth: 600)
+                }
+                .padding(.bottom)
+            }
+        }
+    }
+}
 #else
 private struct VideoPlayerDurationView: View {
     var model:PDPlayerModel

--- a/Sources/PDVideoPlayer/VideoPlayerNavigationView.swift
+++ b/Sources/PDVideoPlayer/VideoPlayerNavigationView.swift
@@ -6,7 +6,38 @@
 //
 
 import SwiftUI
-#if canImport(UIKit) && !os(visionOS)
+#if os(macOS)
+public struct VideoPlayerNavigationView: View {
+    public init() {}
+
+    @Environment(\.videoPlayerCloseAction) private var closeAction
+    @Environment(\.videoPlayerIsMuted) private var isMutedBinding
+    @Environment(\.videoPlayerControlsVisible) private var controlsVisibleBinding
+
+    public var body: some View {
+        VStack {
+            if controlsVisibleBinding?.wrappedValue ?? true {
+                HStack {
+                    Button { closeAction?(0) } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.white)
+                    }
+                    Spacer()
+                    Button {
+                        isMutedBinding?.wrappedValue.toggle()
+                    } label: {
+                        Image(systemName: (isMutedBinding?.wrappedValue ?? false) ? "speaker.slash.fill" : "speaker.fill")
+                            .foregroundStyle(.white)
+                    }
+                }
+                .padding(.horizontal)
+                .frame(height: 44)
+            }
+            Spacer()
+        }
+    }
+}
+#elseif canImport(UIKit) && !os(visionOS)
 public struct VideoPlayerNavigationView:View{
     public init() {}
 


### PR DESCRIPTION
## Summary
- add NSSlider-based `VideoPlayerSliderView` for macOS
- support configuration helpers for macOS `PDVideoPlayerRepresentable`
- track slider interaction in `PDPlayerModel` on macOS

## Testing
- `swift test -l` *(fails: no such module 'SwiftUI')*