### PR TITLE
Fix macOS proxy player type

### DIFF
--- a/Sources/PDVideoPlayer/PDVideoPlayer+macOS.swift
+++ b/Sources/PDVideoPlayer/PDVideoPlayer+macOS.swift
@@ -3,7 +3,7 @@ import SwiftUI
 import AVKit
 
 public struct PDVideoPlayerProxy<MenuContent: View> {
-    public let player: PDVideoPlayerRepresentable
+    public let player: PDVideoPlayerRepresentable<MenuContent>
     public let control: VideoPlayerControlView<MenuContent>
     public let navigation: VideoPlayerNavigationView
 }


### PR DESCRIPTION
## Summary
- fix PDVideoPlayerProxy's player property on macOS

## Testing
- `swift test -c release` *(fails: no such module 'SwiftUI')*