### PR TITLE
Fix compile errors in macOS representable

### DIFF
--- a/Sources/PDVideoPlayer/Player/VideoPlayerViewControllerRepresentable.swift
+++ b/Sources/PDVideoPlayer/Player/VideoPlayerViewControllerRepresentable.swift
@@ -21,9 +21,9 @@ public struct PDVideoPlayerView_macOS<MenuContent: View>: NSViewRepresentable {
     public typealias ResizeAction = ((_ view: NSView, _ size: CGSize) -> Void)
     
     var player: AVPlayer
-    private let menuContent: () -> MenuContent
-    private let resizeAction: ResizeAction?
-    private let playerViewConfigurator:PlayerViewConfigurator?
+    let menuContent: () -> MenuContent
+    let resizeAction: ResizeAction?
+    let playerViewConfigurator: PlayerViewConfigurator?
     
     public init(
         player: AVPlayer,


### PR DESCRIPTION
## Summary
- expose internal properties for PDVideoPlayerView_macOS so extensions can access them

## Testing
- `swift build` *(fails: no SwiftUI module)*
- `swift test` *(fails: no SwiftUI module)*
