### PR TITLE
Enable bindings on macOS

### DIFF
--- a/Sources/PDVideoPlayer/PDVideoPlayerSampleView.swift
+++ b/Sources/PDVideoPlayer/PDVideoPlayerSampleView.swift
@@ -10,7 +10,10 @@ private let sampleURL = URL(fileURLWithPath: "/Users/kn/Downloads/ScreenRecordin
 #if os(macOS)
 struct ContentView: View {
     @State private var player = AVPlayer(url:sampleURL)
-    
+    @State private var isMuted: Bool = true
+    @State private var controlsVisible: Bool = true
+    @State private var originalRate: Float = 1.0
+
     var body: some View {
         PDVideoPlayer(
             url: sampleURL,
@@ -35,6 +38,9 @@ struct ContentView: View {
             }
         )
 
+        .isMuted($isMuted)
+        .controlsVisible($controlsVisible)
+        .originalRate($originalRate)
         .longpressAction { value in
             print("longpressAction",value)
         }

--- a/Sources/PDVideoPlayer/Player/VideoPlayerViewControllerRepresentable.swift
+++ b/Sources/PDVideoPlayer/Player/VideoPlayerViewControllerRepresentable.swift
@@ -38,6 +38,11 @@ public struct PDVideoPlayerView_macOS<MenuContent: View>: NSViewRepresentable {
         
     }
     
+    @Environment(\.videoPlayerCloseAction) private var closeAction
+    @Environment(\.videoPlayerIsMuted) private var isMutedBinding
+    @Environment(\.videoPlayerControlsVisible) private var controlsVisibleBinding
+    @Environment(\.videoPlayerOriginalRate) private var originalRateBinding
+    @Environment(\.videoPlayerLongpressAction) private var longpressAction
     @Environment(\.isPresentedMedia) private var isPresented
     
     
@@ -75,6 +80,7 @@ public struct PDVideoPlayerView_macOS<MenuContent: View>: NSViewRepresentable {
         
         playerView.allowsPictureInPicturePlayback = true
         playerView.player?.appliesMediaSelectionCriteriaAutomatically = false
+        playerView.player?.isMuted = isMutedBinding?.wrappedValue ?? false
         
         if resizeAction != nil, let playerItem = playerView.player?.currentItem {
             context.coordinator.presentationSizeObservation?.invalidate()
@@ -95,6 +101,7 @@ public struct PDVideoPlayerView_macOS<MenuContent: View>: NSViewRepresentable {
     }
 
     public func updateNSView(_ uiView: AVPlayerView, context: Context) {
+        uiView.player?.isMuted = isMutedBinding?.wrappedValue ?? false
         // 必要があれば、動画ソースが変わったときに再監視させるなど
     }
 }

--- a/Sources/PDVideoPlayer/VideoPlayerNavigationView.swift
+++ b/Sources/PDVideoPlayer/VideoPlayerNavigationView.swift
@@ -13,6 +13,7 @@ public struct VideoPlayerNavigationView: View {
     @Environment(\.videoPlayerCloseAction) private var closeAction
     @Environment(\.videoPlayerIsMuted) private var isMutedBinding
     @Environment(\.videoPlayerControlsVisible) private var controlsVisibleBinding
+    @Environment(\.videoPlayerOriginalRate) private var originalRateBinding
 
     public var body: some View {
         VStack {


### PR DESCRIPTION
## Summary
- read video player binding values on macOS
- surface bindings in macOS sample

## Testing
- `swift test --disable-sandbox` *(fails: no such module 'SwiftUI')*