### PR TITLE
Add window drag option for macOS

### DIFF
--- a/Sources/PDVideoPlayer/PDVideoPlayerSampleView.swift
+++ b/Sources/PDVideoPlayer/PDVideoPlayerSampleView.swift
@@ -25,6 +25,7 @@ struct ContentView: View {
             content: { proxy in
                 ZStack {
                     proxy.player
+                        .windowDragEnabled()
                         .ignoresSafeArea()
                     proxy.control
                     VStack {

--- a/Sources/PDVideoPlayer/Player/PDVideoPlayerRepresentable+Extensions-macOS.swift
+++ b/Sources/PDVideoPlayer/Player/PDVideoPlayerRepresentable+Extensions-macOS.swift
@@ -9,5 +9,16 @@ public extension PDVideoPlayerRepresentable {
     func resizeAction(_ action: @escaping ResizeAction) -> Self {
         Self(model: self.model, playerViewConfigurator: self.playerViewConfigurator, resizeAction: action, menuContent: self.menuContent)
     }
+
+    func windowDragEnabled(_ enabled: Bool = true) -> Self {
+        let configurator = self.playerViewConfigurator
+        let newConfigurator: PlayerViewConfigurator = { view in
+            configurator?(view)
+            if let customView = view as? CustomAVPlayerView {
+                customView.enableWindowDrag = enabled
+            }
+        }
+        return Self(model: self.model, playerViewConfigurator: newConfigurator, resizeAction: self.resizeAction, menuContent: self.menuContent)
+    }
 }
 #endif

--- a/Sources/PDVideoPlayer/Player/VideoPlayerViewControllerRepresentable.swift
+++ b/Sources/PDVideoPlayer/Player/VideoPlayerViewControllerRepresentable.swift
@@ -101,11 +101,20 @@ public struct PDVideoPlayerView_macOS<MenuContent: View>: NSViewRepresentable {
 
 class CustomAVPlayerView: AVPlayerView {
     var contextMenu: NSMenu?
+    var enableWindowDrag: Bool = false
     override func menu(for event: NSEvent) -> NSMenu? {
         if let contextMenu = contextMenu {
             return contextMenu
         } else {
             return super.menu(for: event)
+        }
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        if enableWindowDrag, let window {
+            window.performDrag(with: event)
+        } else {
+            super.mouseDown(with: event)
         }
     }
 }


### PR DESCRIPTION
## Summary
- allow dragging the video player view to move its window on macOS
- expose `windowDragEnabled` modifier for configuration
- demo usage in sample view

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*