### PR TITLE
Restrict macOS seek gesture to slider

### DIFF
--- a/Sources/PDVideoPlayer/Player/VideoPlayerViewControllerRepresentable.swift
+++ b/Sources/PDVideoPlayer/Player/VideoPlayerViewControllerRepresentable.swift
@@ -104,6 +104,8 @@ public struct PDVideoPlayerView_macOS<MenuContent: View>: NSViewRepresentable {
     }
 }
 
+private let ADJSUT_GESTURE_INSET: CGFloat = 150
+
 class CustomAVPlayerView: AVPlayerView {
     var contextMenu: NSMenu?
     override func menu(for event: NSEvent) -> NSMenu? {
@@ -112,6 +114,22 @@ class CustomAVPlayerView: AVPlayerView {
         } else {
             return super.menu(for: event)
         }
+    }
+
+    override func scrollWheel(with event: NSEvent) {
+        // Restrict horizontal scrubbing to the area near the bottom slider
+        if abs(event.scrollingDeltaX) > abs(event.scrollingDeltaY) {
+            let location = convert(event.locationInWindow, from: nil)
+            let height = bounds.height
+            let adjustInset = min(ADJSUT_GESTURE_INSET, height / 5)
+            let bottomSafeAreaStart = height - adjustInset
+            if location.y < bottomSafeAreaStart {
+                // Ignore horizontal scrolls outside the slider area
+                nextResponder?.scrollWheel(with: event)
+                return
+            }
+        }
+        super.scrollWheel(with: event)
     }
 }
 public class PlayerNSView: NSView {


### PR DESCRIPTION
## Summary
- ignore trackpad horizontal scrolls outside the slider area on macOS

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*