### PR TITLE
Enable transparent background for macOS player

### DIFF
--- a/Sources/PDVideoPlayer/Player/PDPlayerModel.swift
+++ b/Sources/PDVideoPlayer/Player/PDPlayerModel.swift
@@ -5,6 +5,9 @@
 //  Created by Kazuki Nakashima on 2025/02/16.
 //
 
+#if os(macOS)
+import AppKit
+#endif
 import SwiftUI
 import AVFoundation
 import AVKit
@@ -421,6 +424,10 @@ extension UIView {
     func setupPlayerView() -> CustomAVPlayerView {
         let view = CustomAVPlayerView()
         self.playerView = view
+        view.wantsLayer = true
+        view.isOpaque = false
+        view.layer?.backgroundColor = NSColor.clear.cgColor
+        view.playerLayer.backgroundColor = NSColor.clear.cgColor
         view.player = player
         player.publisher(for: \.timeControlStatus)
             .receive(on: DispatchQueue.main)

--- a/Sources/PDVideoPlayer/Player/VideoPlayerViewControllerRepresentable.swift
+++ b/Sources/PDVideoPlayer/Player/VideoPlayerViewControllerRepresentable.swift
@@ -108,6 +108,13 @@ private let ADJSUT_GESTURE_INSET: CGFloat = 150
 
 class CustomAVPlayerView: AVPlayerView {
     var contextMenu: NSMenu?
+    override var isOpaque: Bool { false }
+
+    override func updateLayer() {
+        super.updateLayer()
+        layer?.backgroundColor = NSColor.clear.cgColor
+        playerLayer.backgroundColor = NSColor.clear.cgColor
+    }
     override func menu(for event: NSEvent) -> NSMenu? {
         if let contextMenu = contextMenu {
             return contextMenu


### PR DESCRIPTION
## Summary
- import AppKit for macOS specific code
- clear background color when building the macOS player view
- override `CustomAVPlayerView` to keep its layer transparent

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*