### PR TITLE
Use AVPlayerLayer for macOS video output

### DIFF
--- a/Sources/PDVideoPlayer/PDVideoPlayer+macOS.swift
+++ b/Sources/PDVideoPlayer/PDVideoPlayer+macOS.swift
@@ -59,7 +59,7 @@ public struct PDVideoPlayer<PlayerMenu: View,
                 let proxy = PDVideoPlayerProxy(
                     player: PDVideoPlayerRepresentable(
                         model: model,
-                        playerViewConfigurator: { $0.controlsStyle = .none },
+                        playerViewConfigurator: { _ in },
                         menuContent: playerMenu
                     ),
                     control: VideoPlayerControlView(

--- a/Sources/PDVideoPlayer/Player/PDPlayerModel.swift
+++ b/Sources/PDVideoPlayer/Player/PDPlayerModel.swift
@@ -420,14 +420,14 @@ extension UIView {
         self.player = player
     }
 
-    private var playerView:CustomAVPlayerView?
-    func setupPlayerView() -> CustomAVPlayerView {
-        let view = CustomAVPlayerView()
+    private var playerView: PlayerNSView?
+    func setupPlayerView() -> PlayerNSView {
+        let view = PlayerNSView()
         self.playerView = view
         view.wantsLayer = true
         view.layer?.isOpaque = false
         view.layer?.backgroundColor = NSColor.clear.cgColor
-        view.player = player
+        view.setPlayer(player, videoGravity: .resizeAspect)
         player.publisher(for: \.timeControlStatus)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] status in

--- a/Sources/PDVideoPlayer/Player/PDVideoPlayerRepresentable+Extensions-macOS.swift
+++ b/Sources/PDVideoPlayer/Player/PDVideoPlayerRepresentable+Extensions-macOS.swift
@@ -10,21 +10,17 @@ public extension PDVideoPlayerRepresentable {
         Self(model: self.model, playerViewConfigurator: self.playerViewConfigurator, resizeAction: action, menuContent: self.menuContent)
     }
 
-    func playerOverlay( _ overlay:some View) -> Self {
+    func playerOverlay(_ overlay: some View) -> Self {
         let configurator = self.playerViewConfigurator
         let newConfigurator: PlayerViewConfigurator = { view in
             configurator?(view)
-            if let customView = view as? CustomAVPlayerView {
-                if let contentOverlayView = customView.contentOverlayView {
-                   let overlayHostingView = NSHostingView(rootView: overlay)
-                   contentOverlayView.addSubview(overlayHostingView)
-                   overlayHostingView.translatesAutoresizingMaskIntoConstraints = false
-                   overlayHostingView.topAnchor.constraint(equalTo: contentOverlayView.topAnchor).isActive = true
-                   overlayHostingView.trailingAnchor.constraint(equalTo: contentOverlayView.trailingAnchor).isActive = true
-                   overlayHostingView.bottomAnchor.constraint(equalTo: contentOverlayView.bottomAnchor).isActive = true
-                   overlayHostingView.leadingAnchor.constraint(equalTo: contentOverlayView.leadingAnchor).isActive = true
-               }
-            }
+            let overlayHostingView = NSHostingView(rootView: overlay)
+            view.addSubview(overlayHostingView)
+            overlayHostingView.translatesAutoresizingMaskIntoConstraints = false
+            overlayHostingView.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
+            overlayHostingView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
+            overlayHostingView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
+            overlayHostingView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
         }
         return Self(model: self.model, playerViewConfigurator: newConfigurator, resizeAction: self.resizeAction, menuContent: self.menuContent)
     }


### PR DESCRIPTION
## Summary
- change macOS player view to `PlayerNSView` which hosts an `AVPlayerLayer`
- update player setup and configurator types for macOS
- remove unused `CustomAVPlayerView`

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*