### PR TITLE
Move originalRate into model

### DIFF
--- a/Sources/PDVideoPlayer/PDVideoPlayer+macOS.swift
+++ b/Sources/PDVideoPlayer/PDVideoPlayer+macOS.swift
@@ -18,7 +18,6 @@ public struct PDVideoPlayer<PlayerMenu: View,
     
     private var isMuted: Binding<Bool>?
     private var controlsVisible: Binding<Bool>?
-    private var originalRate: Binding<Float>?
     private var closeAction: VideoPlayerCloseAction?
     private var longpressAction: VideoPlayerLongpressAction?
     
@@ -73,7 +72,6 @@ public struct PDVideoPlayer<PlayerMenu: View,
                     .environment(model)
                     .environment(\.videoPlayerIsMuted, isMuted)
                     .environment(\.videoPlayerControlsVisible, controlsVisible)
-                    .environment(\.videoPlayerOriginalRate, originalRate)
                     .environment(\.videoPlayerCloseAction, closeAction)
                     .environment(\.videoPlayerLongpressAction, longpressAction)
             }
@@ -136,11 +134,6 @@ public extension PDVideoPlayer {
         return copy
     }
 
-    func originalRate(_ binding: Binding<Float>) -> Self {
-        var copy = self
-        copy.originalRate = binding
-        return copy
-    }
 
     func closeAction(_ action: VideoPlayerCloseAction) -> Self {
         var copy = self

--- a/Sources/PDVideoPlayer/PDVideoPlayer.swift
+++ b/Sources/PDVideoPlayer/PDVideoPlayer.swift
@@ -17,7 +17,6 @@ public struct PDVideoPlayer<MenuContent: View, Content: View>: View {
 
     private var isMuted: Binding<Bool>?
     private var controlsVisible: Binding<Bool>?
-    private var originalRate: Binding<Float>?
     private var closeAction: VideoPlayerCloseAction?
     private var longpressAction: VideoPlayerLongpressAction?
     private var panGesture: PDVideoPlayerPanGesture = .rotation
@@ -67,7 +66,6 @@ public struct PDVideoPlayer<MenuContent: View, Content: View>: View {
                     .environment(model)
                     .environment(\.videoPlayerIsMuted, isMuted)
                     .environment(\.videoPlayerControlsVisible, controlsVisible)
-                    .environment(\.videoPlayerOriginalRate, originalRate)
                     .environment(\.videoPlayerCloseAction, closeAction)
                     .environment(\.videoPlayerLongpressAction, longpressAction)
             }
@@ -122,12 +120,6 @@ public extension PDVideoPlayer {
         return copy
     }
     
-    /// Sets a binding for the original playback rate.
-    func originalRate(_ binding: Binding<Float>) -> Self {
-        var copy = self
-        copy.originalRate = binding
-        return copy
-    }
     
     /// Sets a close action for the player.
     func closeAction(_ action: VideoPlayerCloseAction) -> Self {

--- a/Sources/PDVideoPlayer/PDVideoPlayerSampleView.swift
+++ b/Sources/PDVideoPlayer/PDVideoPlayerSampleView.swift
@@ -12,7 +12,6 @@ struct ContentView: View {
     @State private var player = AVPlayer(url:sampleURL)
     @State private var isMuted: Bool = true
     @State private var controlsVisible: Bool = true
-    @State private var originalRate: Float = 1.0
     
     var body: some View {
         PDVideoPlayer(
@@ -67,7 +66,6 @@ struct ContentView: View {
         
         .isMuted($isMuted)
         .controlsVisible($controlsVisible)
-        .originalRate($originalRate)
         .longpressAction { value in
             print("longpressAction",value)
         }

--- a/Sources/PDVideoPlayer/Player/PDPlayerModel.swift
+++ b/Sources/PDVideoPlayer/Player/PDPlayerModel.swift
@@ -113,6 +113,7 @@ enum SkipDirection {
     private var timeObserverToken: Any?
     private var playerVC:AVPlayerViewController?
     public var isLongpress:Bool = false
+    public var originalRate: Float = 1.0
     public init(
         url: URL
     ) {
@@ -435,6 +436,7 @@ extension UIView {
 
     public var player: AVPlayer
     public var closeAction: VideoPlayerCloseAction?
+    public var originalRate: Float = 1.0
 
     @ObservationIgnored private var cancellables = Set<AnyCancellable>()
     private var timeObserverToken: Any?

--- a/Sources/PDVideoPlayer/Player/VideoPlayerViewControllerRepresentable.swift
+++ b/Sources/PDVideoPlayer/Player/VideoPlayerViewControllerRepresentable.swift
@@ -41,7 +41,6 @@ public struct PDVideoPlayerView_macOS<MenuContent: View>: NSViewRepresentable {
     @Environment(\.videoPlayerCloseAction) private var closeAction
     @Environment(\.videoPlayerIsMuted) private var isMutedBinding
     @Environment(\.videoPlayerControlsVisible) private var controlsVisibleBinding
-    @Environment(\.videoPlayerOriginalRate) private var originalRateBinding
     @Environment(\.videoPlayerLongpressAction) private var longpressAction
     @Environment(\.isPresentedMedia) private var isPresented
     
@@ -215,7 +214,6 @@ public struct PDVideoPlayerView_iOS: UIViewRepresentable {
     @Environment(\.videoPlayerCloseAction) private var closeAction
     @Environment(\.videoPlayerIsMuted) private var isMutedBinding
     @Environment(\.videoPlayerControlsVisible) private var controlsVisibleBinding
-    @Environment(\.videoPlayerOriginalRate) private var originalRateBinding
     @Environment(\.videoPlayerLongpressAction) private var longpressAction
     @Environment(\.isPresentedMedia) private var isPresented
 
@@ -372,17 +370,17 @@ public struct PDVideoPlayerView_iOS: UIViewRepresentable {
             switch recognizer.state {
             case .began:
                 // 今の再生レートを保持
-                self.parent.originalRateBinding?.wrappedValue = model.player.rate
+                self.parent.model.originalRate = model.player.rate
                 // もし再生中であれば（rateが0でなければ）
                 if self.parent.model.isPlaying {
                     // 現在のレートの2倍にする
-                    self.parent.model.player.rate = min((self.parent.originalRateBinding?.wrappedValue ?? 1.0) * 2.0,2.0)
+                    self.parent.model.player.rate = min(self.parent.model.originalRate * 2.0, 2.0)
                     self.parent.model.isLongpress = true
                     self.parent.longpressAction?(true)
                 }
             case .ended, .cancelled, .failed:
                 // 長押し終了時に元のレートに戻す
-                self.parent.model.player.rate = self.parent.originalRateBinding?.wrappedValue ?? self.parent.model.player.rate
+                self.parent.model.player.rate = self.parent.model.originalRate
                 self.parent.model.isLongpress = false
                 self.parent.longpressAction?(false)
             default:

--- a/Sources/PDVideoPlayer/VideoPlayerEnvironment.swift
+++ b/Sources/PDVideoPlayer/VideoPlayerEnvironment.swift
@@ -20,9 +20,6 @@ private struct VideoPlayerIsMutedKey: EnvironmentKey {
 private struct VideoPlayerControlsVisibleKey: EnvironmentKey {
     static let defaultValue: Binding<Bool>? = nil
 }
-private struct VideoPlayerOriginalRateKey: EnvironmentKey {
-    static let defaultValue: Binding<Float>? = nil
-}
 
 public struct VideoPlayerLongpressAction {
     let action: (Bool) -> Void
@@ -50,10 +47,6 @@ public extension EnvironmentValues {
     var videoPlayerControlsVisible: Binding<Bool>? {
         get { self[VideoPlayerControlsVisibleKey.self] }
         set { self[VideoPlayerControlsVisibleKey.self] = newValue }
-    }
-    var videoPlayerOriginalRate: Binding<Float>? {
-        get { self[VideoPlayerOriginalRateKey.self] }
-        set { self[VideoPlayerOriginalRateKey.self] = newValue }
     }
     var videoPlayerLongpressAction: VideoPlayerLongpressAction? {
         get { self[VideoPlayerLongpressActionKey.self] }

--- a/Sources/PDVideoPlayer/VideoPlayerNavigationView.swift
+++ b/Sources/PDVideoPlayer/VideoPlayerNavigationView.swift
@@ -13,7 +13,6 @@ public struct VideoPlayerNavigationView: View {
     @Environment(\.videoPlayerCloseAction) private var closeAction
     @Environment(\.videoPlayerIsMuted) private var isMutedBinding
     @Environment(\.videoPlayerControlsVisible) private var controlsVisibleBinding
-    @Environment(\.videoPlayerOriginalRate) private var originalRateBinding
 
     public var body: some View {
         VStack {
@@ -46,7 +45,6 @@ public struct VideoPlayerNavigationView:View{
     @Environment(\.videoPlayerCloseAction) private var closeAction
     @Environment(\.videoPlayerIsMuted) private var isMutedBinding
     @Environment(\.videoPlayerControlsVisible) private var controlsVisibleBinding
-    @Environment(\.videoPlayerOriginalRate) private var originalRateBinding
     @Environment(PDPlayerModel.self) private var model
     @Environment(\.videoPlayerLongpressAction) private var longpressAction
     public var body:some View{
@@ -96,7 +94,7 @@ public struct VideoPlayerNavigationView:View{
     }
     private var fastView: some View {
         HStack(spacing:4){
-            Text("\(min(2.0,(originalRateBinding?.wrappedValue ?? 1.0) * 2.0), specifier: "%.1f")x")
+            Text("\(min(2.0, model.originalRate * 2.0), specifier: "%.1f")x")
             Image(systemName:"forward.fill")
                 .imageScale(.small)
         }


### PR DESCRIPTION
## Summary
- keep video player playback rate internal to PDPlayerModel
- remove `videoPlayerOriginalRate` environment value
- update navigation and representable views
- update sample view

## Testing
- `swift test 2>&1 | tail -n 20` *(fails: no such module 'SwiftUI')*