### PR TITLE
Allow color customization through player extension

### DIFF
--- a/Sources/PDVideoPlayer/AirPlayRoutePicker.swift
+++ b/Sources/PDVideoPlayer/AirPlayRoutePicker.swift
@@ -10,13 +10,14 @@ import AVKit
 #if os(macOS) || os(visionOS)
 #else
 public struct AirPlayRoutePicker: UIViewRepresentable {
+    @Environment(\.videoPlayerForegroundColor) private var foregroundColor
 
     public func makeUIView(context: Context) -> AVRoutePickerView {
         let picker = AVRoutePickerView()
         picker.prioritizesVideoDevices = true
         picker.contentMode = .scaleAspectFit
         picker.activeTintColor = .systemBlue
-        picker.tintColor = UIColor(Color.white.opacity(0.8))
+        picker.tintColor = UIColor(foregroundColor.opacity(0.8))
 
         if let button = picker.subviews.compactMap({ $0 as? UIButton }).first {
             button.layer.sublayers?.first?.isHidden = true
@@ -42,11 +43,12 @@ public struct AirPlayRoutePicker: UIViewRepresentable {
     }
 }
 struct AirPlayRouteLabelView:View{
+    @Environment(\.videoPlayerForegroundColor) private var foregroundColor
     var body:some View{
         ZStack{
             Color.clear
             Image(systemName:"airplayvideo")
-                .foregroundStyle(.white)
+                .foregroundStyle(foregroundColor)
                 .fontDesign(.rounded)
                 .opacity(0.8)
         }

--- a/Sources/PDVideoPlayer/Effect/RippleEffectModifier.swift
+++ b/Sources/PDVideoPlayer/Effect/RippleEffectModifier.swift
@@ -8,6 +8,7 @@ import SwiftUI
 #if canImport(UIKit)
 struct RippleEffectModifier: ViewModifier {
     @Environment(PDPlayerModel.self) private var model
+    @Environment(\.videoPlayerForegroundColor) private var foregroundColor
     
     func body(content: Content) -> some View {
         content
@@ -78,7 +79,7 @@ struct RippleEffectModifier: ViewModifier {
                         .transition(.opacity)
                         .font(.body)
                         .fontWeight(.bold)
-                        .foregroundStyle(.white)
+                        .foregroundStyle(foregroundColor)
                         .opacity(0.8)
                         .position(x: xPos, y: yPos)
                     }

--- a/Sources/PDVideoPlayer/PDVideoPlayer+macOS.swift
+++ b/Sources/PDVideoPlayer/PDVideoPlayer+macOS.swift
@@ -21,6 +21,7 @@ public struct PDVideoPlayer<PlayerMenu: View,
     private var originalRate: Binding<Float>?
     private var closeAction: VideoPlayerCloseAction?
     private var longpressAction: VideoPlayerLongpressAction?
+    private var foregroundColor: Color = .white
     
     private let playerMenu: () -> PlayerMenu
     private let controlMenu: () -> ControlMenu
@@ -76,6 +77,7 @@ public struct PDVideoPlayer<PlayerMenu: View,
                     .environment(\.videoPlayerOriginalRate, originalRate)
                     .environment(\.videoPlayerCloseAction, closeAction)
                     .environment(\.videoPlayerLongpressAction, longpressAction)
+                    .environment(\.videoPlayerForegroundColor, foregroundColor)
             }
         }
         .task(id: url) {
@@ -163,6 +165,13 @@ public extension PDVideoPlayer {
     func longpressAction(_ action: @escaping (Bool) -> Void) -> Self {
         var copy = self
         copy.longpressAction = VideoPlayerLongpressAction(action)
+        return copy
+    }
+
+    /// Sets the foreground color used for UI elements.
+    func foregroundColor(_ color: Color) -> Self {
+        var copy = self
+        copy.foregroundColor = color
         return copy
     }
 

--- a/Sources/PDVideoPlayer/PDVideoPlayer.swift
+++ b/Sources/PDVideoPlayer/PDVideoPlayer.swift
@@ -20,6 +20,7 @@ public struct PDVideoPlayer<MenuContent: View, Content: View>: View {
     private var originalRate: Binding<Float>?
     private var closeAction: VideoPlayerCloseAction?
     private var longpressAction: VideoPlayerLongpressAction?
+    private var foregroundColor: Color = .white
     private var panGesture: PDVideoPlayerPanGesture = .rotation
 
     private let content: (PDVideoPlayerProxy<MenuContent>) -> Content
@@ -70,6 +71,7 @@ public struct PDVideoPlayer<MenuContent: View, Content: View>: View {
                     .environment(\.videoPlayerOriginalRate, originalRate)
                     .environment(\.videoPlayerCloseAction, closeAction)
                     .environment(\.videoPlayerLongpressAction, longpressAction)
+                    .environment(\.videoPlayerForegroundColor, foregroundColor)
             }
         }
         .task(id: url) {
@@ -154,6 +156,12 @@ public extension PDVideoPlayer {
     func longpressAction(_ action: @escaping (Bool) -> Void) -> Self {
         var copy = self
         copy.longpressAction = VideoPlayerLongpressAction(action)
+        return copy
+    }
+    /// Sets the foreground color used for UI elements.
+    func foregroundColor(_ color: Color) -> Self {
+        var copy = self
+        copy.foregroundColor = color
         return copy
     }
     /// Sets the pan gesture style used for dismissing the video.

--- a/Sources/PDVideoPlayer/Slider/VideoPlayerSlider.swift
+++ b/Sources/PDVideoPlayer/Slider/VideoPlayerSlider.swift
@@ -13,8 +13,9 @@ class VideoPlayerSliderCell: NSSliderCell {
 
     private let knobDiameter: CGFloat = 12
     private let barHeight:    CGFloat = 2
-    private let minColor  = NSColor.white.withAlphaComponent(0.8)
-    private let maxColor  = NSColor.white.withAlphaComponent(0.3)
+    var baseColor: NSColor = .white { didSet { controlView?.needsDisplay = true } }
+    private var minColor: NSColor { baseColor.withAlphaComponent(0.8) }
+    private var maxColor: NSColor { baseColor.withAlphaComponent(0.3) }
     private let verticalInset: CGFloat = 2
 
     override var trackRect: NSRect {
@@ -82,6 +83,10 @@ class VideoPlayerSlider: NSSlider {
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         cell = VideoPlayerSliderCell()
+    }
+    var baseColor: NSColor {
+        get { (cell as? VideoPlayerSliderCell)?.baseColor ?? .white }
+        set { (cell as? VideoPlayerSliderCell)?.baseColor = newValue }
     }
     override var intrinsicContentSize: NSSize {
         let s = super.intrinsicContentSize

--- a/Sources/PDVideoPlayer/Slider/VideoPlayerSliderView.swift
+++ b/Sources/PDVideoPlayer/Slider/VideoPlayerSliderView.swift
@@ -12,6 +12,7 @@ import AppKit
 
 public struct VideoPlayerSliderView: NSViewRepresentable {
     var viewModel: PDPlayerModel
+    @Environment(\.videoPlayerForegroundColor) private var foregroundColor
 
     public init(viewModel: PDPlayerModel) {
         self.viewModel = viewModel
@@ -19,6 +20,7 @@ public struct VideoPlayerSliderView: NSViewRepresentable {
 
     public func makeNSView(context: Context) -> NSSlider {
         let slider = viewModel.slider
+        slider.baseColor = NSColor(foregroundColor)
         slider.minValue = 0
         slider.maxValue = 1
         slider.doubleValue = 0
@@ -114,6 +116,7 @@ public struct VideoPlayerSliderView: NSViewRepresentable {
 #else
 public struct VideoPlayerSliderView: UIViewRepresentable {
     var viewModel: PDPlayerModel
+    @Environment(\.videoPlayerForegroundColor) private var foregroundColor
 
     public init(
         viewModel:PDPlayerModel
@@ -134,8 +137,8 @@ public struct VideoPlayerSliderView: UIViewRepresentable {
             scale: .default
         )
 
-        let leftColor:UIColor = UIColor(Color.white.opacity(0.8))
-        let rightColor:UIColor = UIColor(Color.white.opacity(0.3))
+        let leftColor:UIColor = UIColor(foregroundColor.opacity(0.8))
+        let rightColor:UIColor = UIColor(foregroundColor.opacity(0.3))
 
         let thumbImage = UIImage(systemName: "circle.fill", withConfiguration: config)?
             .withTintColor(leftColor, renderingMode: .alwaysOriginal)

--- a/Sources/PDVideoPlayer/VideoPlayerControlView.swift
+++ b/Sources/PDVideoPlayer/VideoPlayerControlView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 public struct VideoPlayerControlView<MenuContent: View>: View {
     var model: PDPlayerModel
     @Environment(\.videoPlayerControlsVisible) private var controlsVisibleBinding
+    @Environment(\.videoPlayerForegroundColor) private var foregroundColor
 
     private let menuContent: () -> MenuContent
 
@@ -31,12 +32,12 @@ public struct VideoPlayerControlView<MenuContent: View>: View {
                     HStack {
                         Button { model.togglePlay() } label: {
                             Image(systemName: model.isPlaying ? "pause.fill" : "play.fill")
-                                .foregroundStyle(.white)
+                                .foregroundStyle(foregroundColor)
                         }
                         Spacer()
                         Menu(content: menuContent) {
                             Image(systemName: "ellipsis.circle")
-                                .foregroundStyle(.white)
+                                .foregroundStyle(foregroundColor)
                         }
                     }
                     .buttonStyle(.plain)
@@ -55,7 +56,7 @@ private struct VideoPlayerDurationView: View {
         Text("\(formatTime(model.currentTime)) / \(formatTime(model.duration))")
             .monospaced()
             .font(.caption)
-            .foregroundStyle(.white)
+            .foregroundStyle(foregroundColor)
             .opacity(0.8)
     }
     // MARK: - 時刻表示フォーマッタ
@@ -70,7 +71,8 @@ private struct VideoPlayerDurationView: View {
 public struct VideoPlayerControlView<MenuContent: View>: View {
     var model: PDPlayerModel
     @Environment(\.videoPlayerControlsVisible) private var controlsVisibleBinding
-    
+    @Environment(\.videoPlayerForegroundColor) private var foregroundColor
+
     private let menuContent: () -> MenuContent
 
     public init(
@@ -105,7 +107,7 @@ public struct VideoPlayerControlView<MenuContent: View>: View {
                                         .contentShape(Rectangle())
                                     Image(systemName: "ellipsis.circle")
                                         .font(.callout)
-                                        .foregroundStyle(.white)
+                                        .foregroundStyle(foregroundColor)
                                         .opacity(0.8)
                                         .padding(.top, 12)
                                     
@@ -151,7 +153,7 @@ public struct VideoPlayerControlView<MenuContent: View>: View {
                     PlayPauseIcon(model: model)
                     if model.isBuffering{
                         ProgressView()
-                            .tint(.white.opacity(0.8))
+                            .tint(foregroundColor.opacity(0.8))
                     }
                     Spacer(minLength: 0)
                 }
@@ -171,7 +173,7 @@ struct PlayPauseIcon: View {
         Image(systemName: model.isPlaying ? "pause" : "play")
             .symbolVariant(.fill)
             .imageScale(.large)
-            .foregroundStyle(.white)
+            .foregroundStyle(foregroundColor)
             .opacity(0.8)
             .scaleEffect(isPressed ? 0.8 : 1.0)
             .animation(.default, value: isPressed)

--- a/Sources/PDVideoPlayer/VideoPlayerEnvironment.swift
+++ b/Sources/PDVideoPlayer/VideoPlayerEnvironment.swift
@@ -38,6 +38,10 @@ private struct VideoPlayerLongpressActionKey: @preconcurrency EnvironmentKey {
     @MainActor static let defaultValue: VideoPlayerLongpressAction? = nil
 }
 
+private struct VideoPlayerForegroundColorKey: EnvironmentKey {
+    static let defaultValue: Color = .white
+}
+
 public extension EnvironmentValues {
     var videoPlayerCloseAction: VideoPlayerCloseAction? {
         get { self[VideoPlayerCloseActionKey.self] }
@@ -58,5 +62,15 @@ public extension EnvironmentValues {
     var videoPlayerLongpressAction: VideoPlayerLongpressAction? {
         get { self[VideoPlayerLongpressActionKey.self] }
         set { self[VideoPlayerLongpressActionKey.self] = newValue }
+    }
+    var videoPlayerForegroundColor: Color {
+        get { self[VideoPlayerForegroundColorKey.self] }
+        set { self[VideoPlayerForegroundColorKey.self] = newValue }
+    }
+}
+
+public extension View {
+    func videoPlayerForegroundColor(_ color: Color) -> some View {
+        environment(\.videoPlayerForegroundColor, color)
     }
 }

--- a/Sources/PDVideoPlayer/VideoPlayerNavigationView.swift
+++ b/Sources/PDVideoPlayer/VideoPlayerNavigationView.swift
@@ -14,6 +14,7 @@ public struct VideoPlayerNavigationView: View {
     @Environment(\.videoPlayerIsMuted) private var isMutedBinding
     @Environment(\.videoPlayerControlsVisible) private var controlsVisibleBinding
     @Environment(\.videoPlayerOriginalRate) private var originalRateBinding
+    @Environment(\.videoPlayerForegroundColor) private var foregroundColor
 
     public var body: some View {
         VStack {
@@ -21,14 +22,14 @@ public struct VideoPlayerNavigationView: View {
                 HStack {
                     Button { closeAction?(0) } label: {
                         Image(systemName: "xmark.circle.fill")
-                            .foregroundStyle(.white)
+                            .foregroundStyle(foregroundColor)
                     }
                     Spacer()
                     Button {
                         isMutedBinding?.wrappedValue.toggle()
                     } label: {
                         Image(systemName: (isMutedBinding?.wrappedValue ?? false) ? "speaker.slash.fill" : "speaker.fill")
-                            .foregroundStyle(.white)
+                            .foregroundStyle(foregroundColor)
                     }
                 }
                 .buttonStyle(.plain)
@@ -49,6 +50,7 @@ public struct VideoPlayerNavigationView:View{
     @Environment(\.videoPlayerOriginalRate) private var originalRateBinding
     @Environment(PDPlayerModel.self) private var model
     @Environment(\.videoPlayerLongpressAction) private var longpressAction
+    @Environment(\.videoPlayerForegroundColor) private var foregroundColor
     public var body:some View{
         VStack {
             ZStack{
@@ -61,7 +63,7 @@ public struct VideoPlayerNavigationView:View{
                                 ZStack{
                                     Color.clear
                                     Image(systemName:"xmark.circle.fill")
-                                        .foregroundStyle(.white)
+                                        .foregroundStyle(foregroundColor)
                                         .fontDesign(.rounded)
                                         .opacity(0.8)
                                 }
@@ -103,7 +105,7 @@ public struct VideoPlayerNavigationView:View{
         .fontDesign(.rounded)
         .fontWeight(.semibold)
         .font(.callout)
-        .foregroundStyle(.white)
+        .foregroundStyle(foregroundColor)
         .opacity(0.8)
         .padding(.vertical,4)
         .padding(.horizontal,12)
@@ -133,7 +135,7 @@ public struct VideoPlayerNavigationView:View{
                 }
             }
             .contentShape(Rectangle())
-            .foregroundStyle(.white)
+            .foregroundStyle(foregroundColor)
             .fontDesign(.rounded)
             .opacity(0.8)
         }
@@ -145,7 +147,7 @@ public struct VideoPlayerNavigationView:View{
             ZStack{
                 Color.clear
                 Image(systemName:"pip.enter")
-                    .foregroundStyle(.white)
+                    .foregroundStyle(foregroundColor)
                     .fontDesign(.rounded)
                     .opacity(0.8)
             }


### PR DESCRIPTION
## Summary
- add `foregroundColor` property to `PDVideoPlayer` types
- inject `videoPlayerForegroundColor` from player environment
- expose `foregroundColor(_:)` modifier for PDVideoPlayer

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*