### PR TITLE
Add foreground color customization to PDVideoPlayer

### DIFF
--- a/Sources/PDVideoPlayer/PDVideoPlayer+macOS.swift
+++ b/Sources/PDVideoPlayer/PDVideoPlayer+macOS.swift
@@ -20,6 +20,7 @@ public struct PDVideoPlayer<PlayerMenu: View,
     private var controlsVisible: Binding<Bool>?
     private var closeAction: VideoPlayerCloseAction?
     private var longpressAction: VideoPlayerLongpressAction?
+    private var foregroundColor: Color = .white
     
     private let playerMenu: () -> PlayerMenu
     private let controlMenu: () -> ControlMenu
@@ -74,6 +75,7 @@ public struct PDVideoPlayer<PlayerMenu: View,
                     .environment(\.videoPlayerControlsVisible, controlsVisible)
                     .environment(\.videoPlayerCloseAction, closeAction)
                     .environment(\.videoPlayerLongpressAction, longpressAction)
+                    .environment(\.videoPlayerForegroundColor, foregroundColor)
             }
         }
         .task(id: url) {
@@ -156,6 +158,12 @@ public extension PDVideoPlayer {
     func longpressAction(_ action: @escaping (Bool) -> Void) -> Self {
         var copy = self
         copy.longpressAction = VideoPlayerLongpressAction(action)
+        return copy
+    }
+
+    func foregroundColor(_ color: Color) -> Self {
+        var copy = self
+        copy.foregroundColor = color
         return copy
     }
 

--- a/Sources/PDVideoPlayer/PDVideoPlayer.swift
+++ b/Sources/PDVideoPlayer/PDVideoPlayer.swift
@@ -17,6 +17,7 @@ public struct PDVideoPlayer<MenuContent: View, Content: View>: View {
 
     private var isMuted: Binding<Bool>?
     private var controlsVisible: Binding<Bool>?
+    private var foregroundColor: Color = .white
     private var closeAction: VideoPlayerCloseAction?
     private var longpressAction: VideoPlayerLongpressAction?
     private var panGesture: PDVideoPlayerPanGesture = .rotation
@@ -68,6 +69,7 @@ public struct PDVideoPlayer<MenuContent: View, Content: View>: View {
                     .environment(\.videoPlayerControlsVisible, controlsVisible)
                     .environment(\.videoPlayerCloseAction, closeAction)
                     .environment(\.videoPlayerLongpressAction, longpressAction)
+                    .environment(\.videoPlayerForegroundColor, foregroundColor)
             }
         }
         .task(id: url) {
@@ -146,6 +148,12 @@ public extension PDVideoPlayer {
     func longpressAction(_ action: @escaping (Bool) -> Void) -> Self {
         var copy = self
         copy.longpressAction = VideoPlayerLongpressAction(action)
+        return copy
+    }
+    /// Sets the foreground color for player controls.
+    func foregroundColor(_ color: Color) -> Self {
+        var copy = self
+        copy.foregroundColor = color
         return copy
     }
     /// Sets the pan gesture style used for dismissing the video.


### PR DESCRIPTION
## Summary
- allow customizing player foreground color via a new `foregroundColor` option
- expose `foregroundColor` modifier for macOS and iOS players

## Testing
- `swift --version`
- `swift test --list-tests` *(fails: no such module 'SwiftUI')*