### PR TITLE
Disable scroll on macOS when zoomed out

### DIFF
--- a/Sources/PDVideoPlayer/Common/Player/PDPlayerModel.swift
+++ b/Sources/PDVideoPlayer/Common/Player/PDPlayerModel.swift
@@ -437,7 +437,7 @@ extension UIView {
     public var player: AVPlayer
     public var closeAction: VideoPlayerCloseAction?
     public var originalRate: Float = 1.0
-    public var scrollView = NSScrollView()
+    public var scrollView = PlayerScrollView()
 
     @ObservationIgnored private var cancellables = Set<AnyCancellable>()
     private var timeObserverToken: Any?

--- a/Sources/PDVideoPlayer/Common/Player/PlayerScrollView.swift
+++ b/Sources/PDVideoPlayer/Common/Player/PlayerScrollView.swift
@@ -1,0 +1,14 @@
+#if os(macOS)
+import AppKit
+
+/// NSScrollView used in macOS video player.
+/// Disables scrolling when magnification is at the minimum level.
+class PlayerScrollView: NSScrollView {
+    override func scrollWheel(with event: NSEvent) {
+        if magnification <= minMagnification {
+            return
+        }
+        super.scrollWheel(with: event)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- add `PlayerScrollView` for macOS that blocks scrolling when magnification is 1.0
- use `PlayerScrollView` in macOS `PDPlayerModel`

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*