### PR TITLE
Add window dragging support

### DIFF
--- a/Sources/PDVideoPlayer/Common/PDVideoPlayerExtensions.swift
+++ b/Sources/PDVideoPlayer/Common/PDVideoPlayerExtensions.swift
@@ -43,6 +43,15 @@ public extension PDVideoPlayer {
         copy.foregroundColor = color
         return copy
     }
+
+#if os(macOS)
+    /// Allows the window to move when dragging on the player view.
+    func windowDraggable(_ value: Bool = true) -> Self {
+        var copy = self
+        copy.windowDraggable = value
+        return copy
+    }
+#endif
 }
 
 #if os(iOS)

--- a/Sources/PDVideoPlayer/Common/Player/PDPlayerModel.swift
+++ b/Sources/PDVideoPlayer/Common/Player/PDPlayerModel.swift
@@ -437,6 +437,8 @@ extension UIView {
     public var player: AVPlayer
     public var closeAction: VideoPlayerCloseAction?
     public var originalRate: Float = 1.0
+    /// When true, dragging on the player view moves the window.
+    public var windowDraggable: Bool = false
     public var scrollView = PlayerScrollView()
 
     @ObservationIgnored private var cancellables = Set<AnyCancellable>()
@@ -454,6 +456,7 @@ extension UIView {
     func setupPlayerView() -> PlayerNSView {
         let view = PlayerNSView()
         view.model = self
+        view.isWindowDraggable = windowDraggable
         self.playerView = view
         view.wantsLayer = true
         view.layer?.isOpaque = false

--- a/Sources/PDVideoPlayer/Common/Player/VideoPlayerViewControllerRepresentable.swift
+++ b/Sources/PDVideoPlayer/Common/Player/VideoPlayerViewControllerRepresentable.swift
@@ -138,6 +138,9 @@ public struct PDVideoPlayerView_macOS<MenuContent: View>: NSViewRepresentable {
 public class PlayerNSView: NSView {
     weak var model: PDPlayerModel?
 
+    /// When true, dragging on this view moves the containing window.
+    var isWindowDraggable: Bool = false
+
     private var zoomScale: CGFloat = 1.0
     private let minZoom: CGFloat = 1.0
     private let maxZoom: CGFloat = 4.0
@@ -166,6 +169,14 @@ public class PlayerNSView: NSView {
     public override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
         window?.makeFirstResponder(self)
+    }
+
+    public override func mouseDown(with event: NSEvent) {
+        if isWindowDraggable {
+            window?.performDrag(with: event)
+        } else {
+            super.mouseDown(with: event)
+        }
     }
 
     public override func keyDown(with event: NSEvent) {

--- a/Sources/PDVideoPlayer/macOS/PDVideoPlayer_macOS.swift
+++ b/Sources/PDVideoPlayer/macOS/PDVideoPlayer_macOS.swift
@@ -21,6 +21,8 @@ public struct PDVideoPlayer<PlayerMenu: View,
     var closeAction: VideoPlayerCloseAction?
     var longpressAction: VideoPlayerLongpressAction?
     var foregroundColor: Color = .white
+    /// Enables moving the window when dragging on the player view.
+    var windowDraggable: Bool = false
     
     private let playerMenu: () -> PlayerMenu
     private let controlMenu: () -> ControlMenu
@@ -85,6 +87,7 @@ public struct PDVideoPlayer<PlayerMenu: View,
             if let url {
                 let m = PDPlayerModel(url: url)
                 m.closeAction = closeAction
+                m.windowDraggable = windowDraggable
                 model = m
             }
         }
@@ -92,6 +95,7 @@ public struct PDVideoPlayer<PlayerMenu: View,
             if let player {
                 let m = PDPlayerModel(player: player)
                 m.closeAction = closeAction
+                m.windowDraggable = windowDraggable
                 model = m
             }
         }


### PR DESCRIPTION
## Summary
- add option to allow moving the window on drag in macOS
- pass configuration to PlayerNSView via `PDPlayerModel`
- expose `.windowDraggable()` modifier for PDVideoPlayer

## Testing
- `swift test -l` *(fails: no such module 'SwiftUI')*