### PR TITLE
Fix NSPageController gesture conflict

### DIFF
--- a/Sources/PDVideoPlayer/Common/Player/PlayerScrollView.swift
+++ b/Sources/PDVideoPlayer/Common/Player/PlayerScrollView.swift
@@ -6,6 +6,7 @@ import AppKit
 public class PlayerScrollView: NSScrollView {
     public override func scrollWheel(with event: NSEvent) {
         if magnification <= minMagnification {
+            nextResponder?.scrollWheel(with: event)
             return
         }
         super.scrollWheel(with: event)


### PR DESCRIPTION
## Summary
- forward scroll events when the player isn't zoomed in so gestures on surrounding `NSPageController` still work

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*