### PR TITLE
Reset start when at end

### DIFF
--- a/Sources/PDVideoPlayer/Common/Player/PDPlayerModel.swift
+++ b/Sources/PDVideoPlayer/Common/Player/PDPlayerModel.swift
@@ -208,6 +208,9 @@ enum SkipDirection {
     }
     
     func play() {
+        if duration > 0 && (currentTime >= duration || (duration - currentTime) < 0.1) {
+            seek(to: 0)
+        }
         player.play()
     }
     
@@ -510,7 +513,12 @@ extension UIView {
         }
     }
 
-    func play() { player.play() }
+    func play() {
+        if duration > 0 && (currentTime >= duration || (duration - currentTime) < 0.1) {
+            seek(to: 0)
+        }
+        player.play()
+    }
     func pause() { player.pause() }
 
     public func togglePlay() {


### PR DESCRIPTION
## Summary
- check current time when playing
- seek to beginning if playback starts at the end

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*