### PR TITLE
Add SwiftUI keyboard shortcuts

### DIFF
--- a/Sources/PDVideoPlayer/Common/Modifier/VideoPlayerKeyboardShortcutModifier.swift
+++ b/Sources/PDVideoPlayer/Common/Modifier/VideoPlayerKeyboardShortcutModifier.swift
@@ -1,0 +1,36 @@
+#if os(iOS) || os(macOS)
+import SwiftUI
+
+/// Provides keyboard shortcuts for common playback controls.
+struct VideoPlayerKeyboardShortcutModifier: ViewModifier {
+    @Environment(PDPlayerModel.self) private var model
+
+    func body(content: Content) -> some View {
+        content
+            .background(
+                KeyboardShortcutButtons()
+            )
+    }
+
+    @ViewBuilder
+    private func KeyboardShortcutButtons() -> some View {
+        ZStack {
+            Button("") { model.togglePlay() }
+                .keyboardShortcut(.space, modifiers: [])
+            Button("") { model.stepFrames(by: -1) }
+                .keyboardShortcut(.leftArrow, modifiers: [])
+            Button("") { model.stepFrames(by: 1) }
+                .keyboardShortcut(.rightArrow, modifiers: [])
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(.clear)
+    }
+}
+
+extension View {
+    /// Adds keyboard shortcuts for controlling playback.
+    public func videoPlayerKeyboardShortcuts() -> some View {
+        modifier(VideoPlayerKeyboardShortcutModifier())
+    }
+}
+#endif

--- a/Sources/PDVideoPlayer/Common/VideoPlayerControlView.swift
+++ b/Sources/PDVideoPlayer/Common/VideoPlayerControlView.swift
@@ -42,6 +42,7 @@ public struct VideoPlayerControlView<MenuContent: View>: View {
             .padding(.horizontal)
             .padding(.bottom,20)
         }
+        .videoPlayerKeyboardShortcuts()
     }
 }
 #else
@@ -102,14 +103,7 @@ public struct VideoPlayerControlView<MenuContent: View>: View {
                 .padding(.vertical,8)
                 .contentShape(Rectangle())
         }
-        .background{
-            Button("") {
-                model.togglePlay()
-            }
-            .buttonStyle(.plain)
-            .foregroundStyle(.clear)
-            .keyboardShortcut(.space, modifiers: [])
-        }
+        .videoPlayerKeyboardShortcuts()
     }
     
     // MARK: - 再生/一時停止ボタン


### PR DESCRIPTION
## Summary
- add a modifier implementing play/pause and frame stepping shortcuts
- apply the modifier to the video player control view on both platforms

## Testing
- `swift test -v` *(fails: no such module 'SwiftUI')*