### PR TITLE
Fix macOS click handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ struct ContentView: View {
         }) { proxy in
             ZStack {
                 proxy.player
-                    .tapAction {
-                        print("tap")
+                    .tapAction { inside in
+                        print("tap", inside)
                     }
                 VStack {
                     proxy.navigation

--- a/Sources/PDVideoPlayer/Common/PDVideoPlayerSampleView.swift
+++ b/Sources/PDVideoPlayer/Common/PDVideoPlayerSampleView.swift
@@ -27,8 +27,8 @@ struct ContentView: View {
             content: { proxy in
                 ZStack {
                     proxy.player
-                        .tapAction{
-                            print("tapAction")
+                        .tapAction { inside in
+                            print("tapAction", inside)
                         }
 #if os(macOS)
                         .resizeAction({ view, size in

--- a/Sources/PDVideoPlayer/Common/Player/Extensions/TapAction.swift
+++ b/Sources/PDVideoPlayer/Common/Player/Extensions/TapAction.swift
@@ -19,8 +19,12 @@ public extension PDVideoPlayerRepresentable {
         #endif
     }
 
-    func tapAction(_ action: @escaping () -> Void) -> Self {
+    func tapAction(_ action: @escaping (Bool) -> Void) -> Self {
         tapAction(VideoPlayerTapAction(action))
+    }
+
+    func tapAction(_ action: @escaping () -> Void) -> Self {
+        tapAction { _ in action() }
     }
 }
 

--- a/Sources/PDVideoPlayer/Common/Player/VideoPlayerViewControllerRepresentable.swift
+++ b/Sources/PDVideoPlayer/Common/Player/VideoPlayerViewControllerRepresentable.swift
@@ -58,7 +58,15 @@ public struct PDVideoPlayerView_macOS<MenuContent: View>: NSViewRepresentable {
         }
 
         @objc func handleClick(_ recognizer: NSClickGestureRecognizer) {
-            parent.tapAction?()
+            guard let playerView else {
+                parent.tapAction?(true)
+                return
+            }
+
+            let locationInPlayerView = recognizer.location(in: playerView)
+            let videoRect = playerView.videoBounds
+            let inside = videoRect.contains(locationInPlayerView)
+            parent.tapAction?(inside)
         }
     }
     public static func dismantleNSView(
@@ -384,19 +392,24 @@ public struct PDVideoPlayerView_iOS: UIViewRepresentable {
 
         @objc func handleSingleTap(_ recognizer: UITapGestureRecognizer) {
             if self.parent.model.doubleTapCount == 0 {
-                self.parent.tapAction?()
+                var inside = true
+                if let playerView {
+                    let location = recognizer.location(in: playerView.view)
+                    let videoRect = playerView.videoBounds
+                    inside = videoRect.contains(location)
+                }
+                self.parent.tapAction?(inside)
             }
         }
         @objc func handleSingleTap_mac(_ recognizer: UITapGestureRecognizer) {
-            guard let playerView else { return }
+            guard let playerView else {
+                parent.tapAction?(true)
+                return
+            }
             let locationInPlayerView = recognizer.location(in: playerView.view)
             let videoRect = playerView.videoBounds
-
-            if videoRect.contains(locationInPlayerView) {
-                parent.tapAction?()
-            } else {
-                parent.closeAction?(0)
-            }
+            let inside = videoRect.contains(locationInPlayerView)
+            parent.tapAction?(inside)
         }
         @objc func handleLongPress(_ recognizer: UILongPressGestureRecognizer) {
             let model = parent.model

--- a/Sources/PDVideoPlayer/Common/VideoPlayerEnvironment.swift
+++ b/Sources/PDVideoPlayer/Common/VideoPlayerEnvironment.swift
@@ -32,12 +32,12 @@ public struct VideoPlayerLongpressAction {
 }
 
 public struct VideoPlayerTapAction {
-    let action: () -> Void
-    public init(_ action: @escaping () -> Void) {
+    let action: (Bool) -> Void
+    public init(_ action: @escaping (Bool) -> Void) {
         self.action = action
     }
-    public func callAsFunction() {
-        action()
+    public func callAsFunction(_ isInsideVideo: Bool) {
+        action(isInsideVideo)
     }
 }
 


### PR DESCRIPTION
## Summary
- detect clicks outside video bounds on macOS
- unify tapAction between iOS and macOS

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*