### PR TITLE
Use SwiftUI-style action modifier names

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ struct ContentView: View {
         }) { proxy in
             ZStack {
                 proxy.player
-                    .tapAction { inside in
+                    .onTap { inside in
                         print("tap", inside)
                     }
                 VStack {
@@ -61,8 +61,9 @@ struct ContentView: View {
 `PDVideoPlayer` provides several modifiers to customize behavior:
 
 - `isMuted(_:)` – Bind the mute state.
-- `closeAction(_:)` – Handle closing the player.
-- `longpressAction(_:)` – Respond to long‑press gestures.
+- `onClose(_:)` – Handle closing the player.
+- `onLongPress(_:)` – Respond to long‑press gestures.
+- `onResize(_:)` – Observe the presentation size on macOS.
 - `playerForegroundColor(_:)` – Set tint color for controls.
 - `panGesture(_:)` – Choose the pan gesture type on iOS.
 - `windowDraggable(_:)` – Allow dragging the macOS window by the player view.

--- a/Sources/PDVideoPlayer/Common/PDVideoPlayerExtensions.swift
+++ b/Sources/PDVideoPlayer/Common/PDVideoPlayerExtensions.swift
@@ -8,27 +8,27 @@ public extension PDVideoPlayer {
         return copy
     }
     
-    func closeAction(_ action: VideoPlayerCloseAction) -> Self {
+    func onClose(_ action: VideoPlayerCloseAction) -> Self {
         var copy = self
-        copy.closeAction = action
+        copy.onClose = action
         return copy
     }
 
-    func closeAction(_ action: @escaping (CGFloat) -> Void) -> Self {
+    func onClose(_ action: @escaping (CGFloat) -> Void) -> Self {
         var copy = self
-        copy.closeAction = VideoPlayerCloseAction(action)
+        copy.onClose = VideoPlayerCloseAction(action)
         return copy
     }
 
-    func longpressAction(_ action: VideoPlayerLongpressAction) -> Self {
+    func onLongPress(_ action: VideoPlayerLongpressAction) -> Self {
         var copy = self
-        copy.longpressAction = action
+        copy.onLongPress = action
         return copy
     }
 
-    func longpressAction(_ action: @escaping (Bool) -> Void) -> Self {
+    func onLongPress(_ action: @escaping (Bool) -> Void) -> Self {
         var copy = self
-        copy.longpressAction = VideoPlayerLongpressAction(action)
+        copy.onLongPress = VideoPlayerLongpressAction(action)
         return copy
     }
 

--- a/Sources/PDVideoPlayer/Common/PDVideoPlayerSampleView.swift
+++ b/Sources/PDVideoPlayer/Common/PDVideoPlayerSampleView.swift
@@ -27,12 +27,12 @@ struct ContentView: View {
             content: { proxy in
                 ZStack {
                     proxy.player
-                        .tapAction { inside in
+                        .onTap { inside in
                             print("tapAction", inside)
                         }
 #if os(macOS)
-                        .resizeAction({ view, size in
-                            
+                        .onResize({ view, size in
+
                         })
 #endif
                     
@@ -70,11 +70,11 @@ struct ContentView: View {
             }
         )
         .isMuted($isMuted)
-        .longpressAction { value in
-            print("longpressAction",value)
+        .onLongPress { value in
+            print("onLongPress", value)
         }
-        .closeAction { value in
-            print("closeAction",value)
+        .onClose { value in
+            print("onClose", value)
         }
         .playerForegroundColor(.white)
 //        .onHover{ value in

--- a/Sources/PDVideoPlayer/Common/Player/Extensions/RepresentableMac.swift
+++ b/Sources/PDVideoPlayer/Common/Player/Extensions/RepresentableMac.swift
@@ -3,11 +3,11 @@ import SwiftUI
 
 public extension PDVideoPlayerRepresentable {
     func playerViewConfigurator(_ configurator: @escaping PlayerViewConfigurator) -> Self {
-        Self(model: self.model, playerViewConfigurator: configurator, resizeAction: self.resizeAction, tapAction: self.tapAction, menuContent: self.menuContent)
+        Self(model: self.model, playerViewConfigurator: configurator, onResize: self.onResize, tapAction: self.tapAction, menuContent: self.menuContent)
     }
 
-    func resizeAction(_ action: @escaping ResizeAction) -> Self {
-        Self(model: self.model, playerViewConfigurator: self.playerViewConfigurator, resizeAction: action, tapAction: self.tapAction, menuContent: self.menuContent)
+    func onResize(_ action: @escaping ResizeAction) -> Self {
+        Self(model: self.model, playerViewConfigurator: self.playerViewConfigurator, onResize: action, tapAction: self.tapAction, menuContent: self.menuContent)
     }
 }
 #endif

--- a/Sources/PDVideoPlayer/Common/Player/Extensions/TapAction.swift
+++ b/Sources/PDVideoPlayer/Common/Player/Extensions/TapAction.swift
@@ -11,7 +11,7 @@ public extension PDVideoPlayerRepresentable {
         #elseif os(macOS)
         Self(model: self.model,
              playerViewConfigurator: self.playerViewConfigurator,
-             resizeAction: self.resizeAction,
+             onResize: self.onResize,
              tapAction: action,
              menuContent: self.menuContent)
         #else
@@ -25,6 +25,21 @@ public extension PDVideoPlayerRepresentable {
 
     func tapAction(_ action: @escaping () -> Void) -> Self {
         tapAction { _ in action() }
+    }
+
+    /// SwiftUI-style alias for ``tapAction(_:)``.
+    func onTap(_ action: VideoPlayerTapAction) -> Self {
+        tapAction(action)
+    }
+
+    /// SwiftUI-style alias for ``tapAction(_:)``.
+    func onTap(_ action: @escaping (Bool) -> Void) -> Self {
+        tapAction(action)
+    }
+
+    /// SwiftUI-style alias for ``tapAction(_:)``.
+    func onTap(_ action: @escaping () -> Void) -> Self {
+        tapAction(action)
     }
 }
 

--- a/Sources/PDVideoPlayer/Common/Player/PDPlayerModel.swift
+++ b/Sources/PDVideoPlayer/Common/Player/PDPlayerModel.swift
@@ -34,7 +34,7 @@ enum SkipDirection {
     @ObservationIgnored private var cancellables = Set<AnyCancellable>()
     
     public var player: AVPlayer
-    public var closeAction: VideoPlayerCloseAction?
+    public var onClose: VideoPlayerCloseAction?
     
     var doubleTapCount: Int = 0
     private var doubleTapBaseTime: Double = 0
@@ -317,7 +317,7 @@ extension PDPlayerModel:UIGestureRecognizerDelegate{
                 } else if stoptime < 0.2 {
                     stoptime = 0.2
                 }
-                closeAction?(stoptime * 0.5)
+                onClose?(stoptime * 0.5)
                
                 UIView.animate(withDuration: stoptime, delay: 0, options: .curveLinear, animations: {
                     containerView.center = CGPoint(
@@ -374,7 +374,7 @@ extension PDPlayerModel:UIGestureRecognizerDelegate{
                 } else if stoptime < 0.18{
                     stoptime = 0.15
                 }
-                closeAction?(stoptime * 0.5)
+                onClose?(stoptime * 0.5)
            
                 UIView.animate(withDuration: stoptime, delay: 0, options: .curveLinear, animations: {
                     containerView.center = CGPoint(
@@ -439,7 +439,7 @@ extension UIView {
     public var isBuffering: Bool = false
     
     public var player: AVPlayer
-    public var closeAction: VideoPlayerCloseAction?
+    public var onClose: VideoPlayerCloseAction?
     public var originalRate: Float = 1.0
     /// When true, dragging on the player view moves the window.
     public var windowDraggable: Bool = false

--- a/Sources/PDVideoPlayer/Common/VideoPlayerEnvironment.swift
+++ b/Sources/PDVideoPlayer/Common/VideoPlayerEnvironment.swift
@@ -11,7 +11,7 @@ public struct VideoPlayerCloseAction {
     }
 }
 
-private struct VideoPlayerCloseActionKey: @preconcurrency EnvironmentKey {
+private struct VideoPlayerOnCloseKey: @preconcurrency EnvironmentKey {
     @MainActor static let defaultValue: VideoPlayerCloseAction? = nil
 }
 private struct VideoPlayerIsMutedKey: EnvironmentKey {
@@ -41,7 +41,7 @@ public struct VideoPlayerTapAction {
     }
 }
 
-private struct VideoPlayerLongpressActionKey: @preconcurrency EnvironmentKey {
+private struct VideoPlayerOnLongPressKey: @preconcurrency EnvironmentKey {
     @MainActor static let defaultValue: VideoPlayerLongpressAction? = nil
 }
 
@@ -50,17 +50,17 @@ private struct VideoPlayerForegroundColorKey: EnvironmentKey {
 }
 
 public extension EnvironmentValues {
-    var videoPlayerCloseAction: VideoPlayerCloseAction? {
-        get { self[VideoPlayerCloseActionKey.self] }
-        set { self[VideoPlayerCloseActionKey.self] = newValue }
+    var videoPlayerOnClose: VideoPlayerCloseAction? {
+        get { self[VideoPlayerOnCloseKey.self] }
+        set { self[VideoPlayerOnCloseKey.self] = newValue }
     }
     var videoPlayerIsMuted: Binding<Bool>? {
         get { self[VideoPlayerIsMutedKey.self] }
         set { self[VideoPlayerIsMutedKey.self] = newValue }
     }
-    var videoPlayerLongpressAction: VideoPlayerLongpressAction? {
-        get { self[VideoPlayerLongpressActionKey.self] }
-        set { self[VideoPlayerLongpressActionKey.self] = newValue }
+    var videoPlayerOnLongPress: VideoPlayerLongpressAction? {
+        get { self[VideoPlayerOnLongPressKey.self] }
+        set { self[VideoPlayerOnLongPressKey.self] = newValue }
     }
     var videoPlayerForegroundColor: Color {
         get { self[VideoPlayerForegroundColorKey.self] }

--- a/Sources/PDVideoPlayer/Common/VideoPlayerNavigationView.swift
+++ b/Sources/PDVideoPlayer/Common/VideoPlayerNavigationView.swift
@@ -10,13 +10,13 @@ import SwiftUI
 public struct VideoPlayerNavigationView: View {
     public init() {}
 
-    @Environment(\.videoPlayerCloseAction) private var closeAction
+    @Environment(\.videoPlayerOnClose) private var onClose
     @Environment(\.videoPlayerIsMuted) private var isMutedBinding
     @Environment(\.videoPlayerForegroundColor) private var foregroundColor
 
     public var body: some View {
         HStack {
-            Button { closeAction?(0) } label: {
+            Button { onClose?(0) } label: {
                 Image(systemName: "xmark.circle.fill")
                     .foregroundStyle(foregroundColor)
             }
@@ -35,17 +35,17 @@ public struct VideoPlayerNavigationView: View {
 public struct VideoPlayerNavigationView:View{
     public init() {}
 
-    @Environment(\.videoPlayerCloseAction) private var closeAction
+    @Environment(\.videoPlayerOnClose) private var onClose
     @Environment(\.videoPlayerIsMuted) private var isMutedBinding
     @Environment(PDPlayerModel.self) private var model
-    @Environment(\.videoPlayerLongpressAction) private var longpressAction
+    @Environment(\.videoPlayerOnLongPress) private var onLongPress
     @Environment(\.videoPlayerForegroundColor) private var foregroundColor
     public var body:some View{
         VStack {
             HStack(spacing:4){
                 if UIDevice.current.userInterfaceIdiom == .pad{
                     Button {
-                        closeAction?(0)
+                        onClose?(0)
                     } label: {
                         ZStack{
                             Color.clear
@@ -75,7 +75,7 @@ public struct VideoPlayerNavigationView:View{
         }
         .animation(.smooth(duration:0.12),value:model.isLongpress)
         .onChange(of: model.isLongpress) {
-            longpressAction?(model.isLongpress)
+            onLongPress?(model.isLongpress)
         }
         
     }

--- a/Sources/PDVideoPlayer/iOS/PDVideoPlayer_iOS.swift
+++ b/Sources/PDVideoPlayer/iOS/PDVideoPlayer_iOS.swift
@@ -17,8 +17,8 @@ public struct PDVideoPlayer<MenuContent: View, Content: View>: View {
 
     var isMuted: Binding<Bool>?
     var foregroundColor: Color = .white
-    var closeAction: VideoPlayerCloseAction?
-    var longpressAction: VideoPlayerLongpressAction?
+    var onClose: VideoPlayerCloseAction?
+    var onLongPress: VideoPlayerLongpressAction?
     var panGesture: PDVideoPlayerPanGesture = .rotation
 
     private let content: (PDVideoPlayerProxy<MenuContent>) -> Content
@@ -63,8 +63,8 @@ public struct PDVideoPlayer<MenuContent: View, Content: View>: View {
                 .videoPlayerKeyboardShortcuts(model)
                 .environment(model)
                 .environment(\.videoPlayerIsMuted, isMuted)
-                .environment(\.videoPlayerCloseAction, closeAction)
-                .environment(\.videoPlayerLongpressAction, longpressAction)
+                .environment(\.videoPlayerOnClose, onClose)
+                .environment(\.videoPlayerOnLongPress, onLongPress)
                 .environment(\.videoPlayerForegroundColor, foregroundColor)
                 .onChange(of: isMuted?.wrappedValue){
                     if let isMuted{
@@ -108,11 +108,11 @@ public struct PDVideoPlayer<MenuContent: View, Content: View>: View {
     ){
         if let url{
             let newModel = PDPlayerModel(url: url)
-            newModel.closeAction = closeAction
+            newModel.onClose = onClose
             model = newModel
         }else if let player{
             let newModel = PDPlayerModel(player: player)
-            newModel.closeAction = closeAction
+            newModel.onClose = onClose
             model = newModel
         }
     }

--- a/Sources/PDVideoPlayer/macOS/PDVideoPlayer_macOS.swift
+++ b/Sources/PDVideoPlayer/macOS/PDVideoPlayer_macOS.swift
@@ -17,8 +17,8 @@ public struct PDVideoPlayer<PlayerMenu: View,
     private var player: AVPlayer?
     
     var isMuted: Binding<Bool>?
-    var closeAction: VideoPlayerCloseAction?
-    var longpressAction: VideoPlayerLongpressAction?
+    var onClose: VideoPlayerCloseAction?
+    var onLongPress: VideoPlayerLongpressAction?
     var foregroundColor: Color = .white
     /// Enables moving the window when dragging on the player view.
     var windowDraggable: Bool = false
@@ -70,8 +70,8 @@ public struct PDVideoPlayer<PlayerMenu: View,
                 .videoPlayerKeyboardShortcuts(model)
                 .environment(model)
                 .environment(\.videoPlayerIsMuted, isMuted)
-                .environment(\.videoPlayerCloseAction, closeAction)
-                .environment(\.videoPlayerLongpressAction, longpressAction)
+                .environment(\.videoPlayerOnClose, onClose)
+                .environment(\.videoPlayerOnLongPress, onLongPress)
                 .environment(\.videoPlayerForegroundColor, foregroundColor)
                 .onChange(of: isMuted?.wrappedValue){
                     if let isMuted{
@@ -100,12 +100,12 @@ public struct PDVideoPlayer<PlayerMenu: View,
     ){
         if let url{
             let m = PDPlayerModel(url: url)
-            m.closeAction = closeAction
+            m.onClose = onClose
             m.windowDraggable = windowDraggable
             model = m
         }else if let player{
             let m = PDPlayerModel(player: player)
-            m.closeAction = closeAction
+            m.onClose = onClose
             m.windowDraggable = windowDraggable
             model = m
         }


### PR DESCRIPTION
## Summary
- rename all callbacks to `onClose`, `onLongPress`, and `onResize`
- update environment keys to `videoPlayerOnClose` and `videoPlayerOnLongPress`
- adjust representables, models and extensions to use the new properties
- document `onResize` in the README and update sample usage

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*