### PR TITLE
Rename onResize to onPresentationSizeChange

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ struct ContentView: View {
 - `isMuted(_:)` – Bind the mute state.
 - `onClose(_:)` – Handle closing the player.
 - `onLongPress(_:)` – Respond to long‑press gestures.
-- `onResize(_:)` – Observe the presentation size on macOS.
+- `onPresentationSizeChange(_:)` – Observe the presentation size on macOS.
 - `playerForegroundColor(_:)` – Set tint color for controls.
 - `panGesture(_:)` – Choose the pan gesture type on iOS.
 - `windowDraggable(_:)` – Allow dragging the macOS window by the player view.

--- a/Sources/PDVideoPlayer/Common/PDVideoPlayerSampleView.swift
+++ b/Sources/PDVideoPlayer/Common/PDVideoPlayerSampleView.swift
@@ -31,7 +31,7 @@ struct ContentView: View {
                             print("tapAction", inside)
                         }
 #if os(macOS)
-                        .onResize({ view, size in
+                        .onPresentationSizeChange({ view, size in
 
                         })
 #endif

--- a/Sources/PDVideoPlayer/Common/Player/Extensions/RepresentableMac.swift
+++ b/Sources/PDVideoPlayer/Common/Player/Extensions/RepresentableMac.swift
@@ -3,11 +3,11 @@ import SwiftUI
 
 public extension PDVideoPlayerRepresentable {
     func playerViewConfigurator(_ configurator: @escaping PlayerViewConfigurator) -> Self {
-        Self(model: self.model, playerViewConfigurator: configurator, onResize: self.onResize, tapAction: self.tapAction, menuContent: self.menuContent)
+        Self(model: self.model, playerViewConfigurator: configurator, onPresentationSizeChange: self.onPresentationSizeChange, tapAction: self.tapAction, menuContent: self.menuContent)
     }
 
-    func onResize(_ action: @escaping ResizeAction) -> Self {
-        Self(model: self.model, playerViewConfigurator: self.playerViewConfigurator, onResize: action, tapAction: self.tapAction, menuContent: self.menuContent)
+    func onPresentationSizeChange(_ action: @escaping PresentationSizeAction) -> Self {
+        Self(model: self.model, playerViewConfigurator: self.playerViewConfigurator, onPresentationSizeChange: action, tapAction: self.tapAction, menuContent: self.menuContent)
     }
 }
 #endif

--- a/Sources/PDVideoPlayer/Common/Player/Extensions/TapAction.swift
+++ b/Sources/PDVideoPlayer/Common/Player/Extensions/TapAction.swift
@@ -11,7 +11,7 @@ public extension PDVideoPlayerRepresentable {
         #elseif os(macOS)
         Self(model: self.model,
              playerViewConfigurator: self.playerViewConfigurator,
-             onResize: self.onResize,
+             onPresentationSizeChange: self.onPresentationSizeChange,
              tapAction: action,
              menuContent: self.menuContent)
         #else

--- a/Sources/PDVideoPlayer/Common/Player/VideoPlayerViewControllerRepresentable.swift
+++ b/Sources/PDVideoPlayer/Common/Player/VideoPlayerViewControllerRepresentable.swift
@@ -21,25 +21,25 @@ public typealias PDVideoPlayerRepresentable = PDVideoPlayerView_macOS
 public struct PDVideoPlayerView_macOS<MenuContent: View>: NSViewRepresentable {
     public typealias ContextMenuProvider = (CGPoint) -> NSMenu?
     public typealias PlayerViewConfigurator = (PlayerNSView) -> Void
-    public typealias ResizeAction = ((_ view: NSView, _ size: CGSize) -> Void)
+    public typealias PresentationSizeAction = ((_ view: NSView, _ size: CGSize) -> Void)
     
     var model: PDPlayerModel
     let menuContent: () -> MenuContent
-    let onResize: ResizeAction?
+    let onPresentationSizeChange: PresentationSizeAction?
     let playerViewConfigurator: PlayerViewConfigurator?
     let tapAction: VideoPlayerTapAction?
     
     public init(
         model: PDPlayerModel,
         playerViewConfigurator:PlayerViewConfigurator? = nil,
-        onResize: ResizeAction? = nil,
+        onPresentationSizeChange: PresentationSizeAction? = nil,
         tapAction: VideoPlayerTapAction? = nil,
         @ViewBuilder menuContent: @escaping () -> MenuContent
     ) {
         self.model = model
         self.playerViewConfigurator = playerViewConfigurator
         self.menuContent = menuContent
-        self.onResize = onResize
+        self.onPresentationSizeChange = onPresentationSizeChange
         self.tapAction = tapAction
         
     }
@@ -132,7 +132,7 @@ public struct PDVideoPlayerView_macOS<MenuContent: View>: NSViewRepresentable {
 
         model.player.appliesMediaSelectionCriteriaAutomatically = false
 
-        if onResize != nil, let playerItem = model.player.currentItem {
+        if onPresentationSizeChange != nil, let playerItem = model.player.currentItem {
             context.coordinator.presentationSizeObservation?.invalidate()
             context.coordinator.presentationSizeObservation = nil
             context.coordinator.presentationSizeObservation = playerItem.observe(\.presentationSize, options: [.new, .initial]) { item, change in
@@ -141,7 +141,7 @@ public struct PDVideoPlayerView_macOS<MenuContent: View>: NSViewRepresentable {
                     Task{ @MainActor in
                         context.coordinator.presentationSizeObservation?.invalidate()
                         context.coordinator.presentationSizeObservation = nil
-                        onResize?(playerView,size)
+                        onPresentationSizeChange?(playerView,size)
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- rename `onResize` to `onPresentationSizeChange`
- update sample and README for the new API

## Testing
- `swift test -v` *(fails: no such module 'SwiftUI')*