### PR TITLE
Replace remaining tapAction usages

### DIFF
--- a/Sources/PDVideoPlayer/Common/PDVideoPlayerSampleView.swift
+++ b/Sources/PDVideoPlayer/Common/PDVideoPlayerSampleView.swift
@@ -28,7 +28,7 @@ struct ContentView: View {
                 ZStack {
                     proxy.player
                         .onTap { inside in
-                            print("tapAction", inside)
+                            print("onTap", inside)
                         }
 #if os(macOS)
                         .onResize({ view, size in

--- a/Sources/PDVideoPlayer/Common/Player/Extensions/ProxyExtensions.swift
+++ b/Sources/PDVideoPlayer/Common/Player/Extensions/ProxyExtensions.swift
@@ -7,7 +7,7 @@ public extension PDVideoPlayerProxy {
         panGesture: PDVideoPlayerPanGesture? = nil,
         scrollViewConfigurator: PDVideoPlayerRepresentable.ScrollViewConfigurator? = nil,
         contextMenuProvider: PDVideoPlayerRepresentable.ContextMenuProvider? = nil,
-        tapAction: VideoPlayerTapAction? = nil
+        onTap: VideoPlayerTapAction? = nil
     ) -> PDVideoPlayerRepresentable {
         var view = self.player
         if let panGesture {
@@ -19,8 +19,8 @@ public extension PDVideoPlayerProxy {
         if let contextMenuProvider {
             view = view.contextMenuProvider(contextMenuProvider)
         }
-        if let tapAction {
-            view = view.tapAction(tapAction)
+        if let onTap {
+            view = view.onTap(onTap)
         }
         return view
     }

--- a/Sources/PDVideoPlayer/Common/Player/Extensions/RepresentableIOS.swift
+++ b/Sources/PDVideoPlayer/Common/Player/Extensions/RepresentableIOS.swift
@@ -3,15 +3,15 @@ import SwiftUI
 
 public extension PDVideoPlayerRepresentable {
     func scrollViewConfigurator(_ configurator: @escaping ScrollViewConfigurator) -> Self {
-        Self(model: self.model, panGesture: self.panGesture, scrollViewConfigurator: configurator, contextMenuProvider: self.contextMenuProvider, tapAction: self.tapAction)
+        Self(model: self.model, panGesture: self.panGesture, scrollViewConfigurator: configurator, contextMenuProvider: self.contextMenuProvider, onTap: self.onTap)
     }
 
     func contextMenuProvider(_ provider: @escaping ContextMenuProvider) -> Self {
-        Self(model: self.model, panGesture: self.panGesture, scrollViewConfigurator: self.scrollViewConfigurator, contextMenuProvider: provider, tapAction: self.tapAction)
+        Self(model: self.model, panGesture: self.panGesture, scrollViewConfigurator: self.scrollViewConfigurator, contextMenuProvider: provider, onTap: self.onTap)
     }
 
     func panGesture(_ gesture: PDVideoPlayerPanGesture) -> Self {
-        Self(model: self.model, panGesture: gesture, scrollViewConfigurator: self.scrollViewConfigurator, contextMenuProvider: self.contextMenuProvider, tapAction: self.tapAction)
+        Self(model: self.model, panGesture: gesture, scrollViewConfigurator: self.scrollViewConfigurator, contextMenuProvider: self.contextMenuProvider, onTap: self.onTap)
     }
 }
 #endif

--- a/Sources/PDVideoPlayer/Common/Player/Extensions/RepresentableMac.swift
+++ b/Sources/PDVideoPlayer/Common/Player/Extensions/RepresentableMac.swift
@@ -3,11 +3,11 @@ import SwiftUI
 
 public extension PDVideoPlayerRepresentable {
     func playerViewConfigurator(_ configurator: @escaping PlayerViewConfigurator) -> Self {
-        Self(model: self.model, playerViewConfigurator: configurator, onResize: self.onResize, tapAction: self.tapAction, menuContent: self.menuContent)
+        Self(model: self.model, playerViewConfigurator: configurator, onResize: self.onResize, onTap: self.onTap, menuContent: self.menuContent)
     }
 
     func onResize(_ action: @escaping ResizeAction) -> Self {
-        Self(model: self.model, playerViewConfigurator: self.playerViewConfigurator, onResize: action, tapAction: self.tapAction, menuContent: self.menuContent)
+        Self(model: self.model, playerViewConfigurator: self.playerViewConfigurator, onResize: action, onTap: self.onTap, menuContent: self.menuContent)
     }
 }
 #endif

--- a/Sources/PDVideoPlayer/Common/Player/Extensions/TapAction.swift
+++ b/Sources/PDVideoPlayer/Common/Player/Extensions/TapAction.swift
@@ -1,45 +1,31 @@
 import SwiftUI
 
 public extension PDVideoPlayerRepresentable {
-    func tapAction(_ action: VideoPlayerTapAction) -> Self {
+    func onTap(_ action: VideoPlayerTapAction) -> Self {
         #if os(iOS)
         Self(model: self.model,
              panGesture: self.panGesture,
              scrollViewConfigurator: self.scrollViewConfigurator,
              contextMenuProvider: self.contextMenuProvider,
-             tapAction: action)
+             onTap: action)
         #elseif os(macOS)
         Self(model: self.model,
              playerViewConfigurator: self.playerViewConfigurator,
              onResize: self.onResize,
-             tapAction: action,
+             onTap: action,
              menuContent: self.menuContent)
         #else
         self
         #endif
     }
 
-    func tapAction(_ action: @escaping (Bool) -> Void) -> Self {
-        tapAction(VideoPlayerTapAction(action))
-    }
-
-    func tapAction(_ action: @escaping () -> Void) -> Self {
-        tapAction { _ in action() }
-    }
-
-    /// SwiftUI-style alias for ``tapAction(_:)``.
-    func onTap(_ action: VideoPlayerTapAction) -> Self {
-        tapAction(action)
-    }
-
-    /// SwiftUI-style alias for ``tapAction(_:)``.
     func onTap(_ action: @escaping (Bool) -> Void) -> Self {
-        tapAction(action)
+        onTap(VideoPlayerTapAction(action))
     }
 
-    /// SwiftUI-style alias for ``tapAction(_:)``.
     func onTap(_ action: @escaping () -> Void) -> Self {
-        tapAction(action)
+        onTap { _ in action() }
     }
+
 }
 

--- a/Sources/PDVideoPlayer/Common/Player/VideoPlayerViewControllerRepresentable.swift
+++ b/Sources/PDVideoPlayer/Common/Player/VideoPlayerViewControllerRepresentable.swift
@@ -27,20 +27,20 @@ public struct PDVideoPlayerView_macOS<MenuContent: View>: NSViewRepresentable {
     let menuContent: () -> MenuContent
     let onResize: ResizeAction?
     let playerViewConfigurator: PlayerViewConfigurator?
-    let tapAction: VideoPlayerTapAction?
+    let onTap: VideoPlayerTapAction?
     
     public init(
         model: PDPlayerModel,
         playerViewConfigurator:PlayerViewConfigurator? = nil,
         onResize: ResizeAction? = nil,
-        tapAction: VideoPlayerTapAction? = nil,
+        onTap: VideoPlayerTapAction? = nil,
         @ViewBuilder menuContent: @escaping () -> MenuContent
     ) {
         self.model = model
         self.playerViewConfigurator = playerViewConfigurator
         self.menuContent = menuContent
         self.onResize = onResize
-        self.tapAction = tapAction
+        self.onTap = onTap
         
     }
     
@@ -58,14 +58,14 @@ public struct PDVideoPlayerView_macOS<MenuContent: View>: NSViewRepresentable {
 
         @objc func handleClick(_ recognizer: NSClickGestureRecognizer) {
             guard let playerView else {
-                parent.tapAction?(true)
+                parent.onTap?(true)
                 return
             }
 
             let locationInPlayerView = recognizer.location(in: playerView)
             let videoRect = playerView.videoBounds
             let inside = videoRect.contains(locationInPlayerView)
-            parent.tapAction?(inside)
+            parent.onTap?(inside)
         }
     }
     public static func dismantleNSView(
@@ -239,21 +239,21 @@ public struct PDVideoPlayerView_iOS: UIViewRepresentable {
     let panGesture: PDVideoPlayerPanGesture
     let scrollViewConfigurator: ScrollViewConfigurator?
     let contextMenuProvider: ContextMenuProvider?
-    let tapAction: VideoPlayerTapAction?
+    let onTap: VideoPlayerTapAction?
  
     public init(
         model: PDPlayerModel,
         panGesture: PDVideoPlayerPanGesture = .rotation,
         scrollViewConfigurator: ScrollViewConfigurator? = nil,
         contextMenuProvider: ContextMenuProvider? = nil,
-        tapAction: VideoPlayerTapAction? = nil
+        onTap: VideoPlayerTapAction? = nil
 
     ) {
         self.model = model
         self.panGesture = panGesture
         self.scrollViewConfigurator = scrollViewConfigurator
         self.contextMenuProvider = contextMenuProvider
-        self.tapAction = tapAction
+        self.onTap = onTap
     }
     @Environment(\.videoPlayerOnLongPress) private var onLongPress
 
@@ -396,18 +396,18 @@ public struct PDVideoPlayerView_iOS: UIViewRepresentable {
                     let videoRect = playerView.videoBounds
                     inside = videoRect.contains(location)
                 }
-                self.parent.tapAction?(inside)
+                self.parent.onTap?(inside)
             }
         }
         @objc func handleSingleTap_mac(_ recognizer: UITapGestureRecognizer) {
             guard let playerView else {
-                parent.tapAction?(true)
+                parent.onTap?(true)
                 return
             }
             let locationInPlayerView = recognizer.location(in: playerView.view)
             let videoRect = playerView.videoBounds
             let inside = videoRect.contains(locationInPlayerView)
-            parent.tapAction?(inside)
+            parent.onTap?(inside)
         }
         @objc func handleLongPress(_ recognizer: UILongPressGestureRecognizer) {
             let model = parent.model


### PR DESCRIPTION
## Summary
- rename `tapAction` parameters and properties to `onTap`
- update extension methods and provide deprecated aliases
- fix sample view printout
- remove deprecated tapAction aliases

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*