### PR TITLE
Rename panGesture to closeGesture

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - Universal support for **iOS** and **macOS** using the same code base.
 - Picture-in-Picture on iOS via `PiPManager`.
 - AirPlay route picker for streaming to external displays.
-- Gesture handling including double-tap skip with ripple effects, long press speed changes, and optional pan gestures for rotation or vertical seeking.
+- Gesture handling including double-tap skip with ripple effects, long press speed changes, and optional close gestures for rotation or vertical seeking.
 - Customizable keyboard shortcuts for quick navigation.
 - Environment driven configuration such as mute state, close actions, long‑press callbacks and foreground color.
 - Built using pure SwiftUI with minimal dependencies.
@@ -65,7 +65,7 @@ struct ContentView: View {
 - `onLongPress(_:)` – Respond to long‑press gestures.
 - `onPresentationSizeChange(_:)` – Observe the presentation size on macOS.
 - `playerForegroundColor(_:)` – Set tint color for controls.
-- `panGesture(_:)` – Choose the pan gesture type on iOS.
+- `closeGesture(_:)` – Choose the close gesture type on iOS.
 - `windowDraggable(_:)` – Allow dragging the macOS window by the player view.
 
 ## License

--- a/Sources/PDVideoPlayer/Common/PDVideoPlayerExtensions.swift
+++ b/Sources/PDVideoPlayer/Common/PDVideoPlayerExtensions.swift
@@ -50,9 +50,9 @@ public extension PDVideoPlayer {
 
 #if os(iOS)
 public extension PDVideoPlayer {
-    func panGesture(_ gesture: PDVideoPlayerPanGesture) -> Self {
+    func closeGesture(_ gesture: PDVideoPlayerCloseGesture) -> Self {
         var copy = self
-        copy.panGesture = gesture
+        copy.closeGesture = gesture
         return copy
     }
 }

--- a/Sources/PDVideoPlayer/Common/PDVideoPlayerSampleView.swift
+++ b/Sources/PDVideoPlayer/Common/PDVideoPlayerSampleView.swift
@@ -37,7 +37,7 @@ struct ContentView: View {
 #endif
                     
 #if os(iOS)
-                        .panGesture(.rotation)
+                        .closeGesture(.rotation)
                         .contextMenuProvider{ location in
                             let contextMenus :[UIMenuElement] = [
                                 UIAction(

--- a/Sources/PDVideoPlayer/Common/Player/Extensions/ProxyExtensions.swift
+++ b/Sources/PDVideoPlayer/Common/Player/Extensions/ProxyExtensions.swift
@@ -4,14 +4,14 @@ import SwiftUI
 @MainActor
 public extension PDVideoPlayerProxy {
     func player(
-        panGesture: PDVideoPlayerPanGesture? = nil,
+        closeGesture: PDVideoPlayerCloseGesture? = nil,
         scrollViewConfigurator: PDVideoPlayerRepresentable.ScrollViewConfigurator? = nil,
         contextMenuProvider: PDVideoPlayerRepresentable.ContextMenuProvider? = nil,
         onTap: VideoPlayerTapAction? = nil
     ) -> PDVideoPlayerRepresentable {
         var view = self.player
-        if let panGesture {
-            view = view.panGesture(panGesture)
+        if let closeGesture {
+            view = view.closeGesture(closeGesture)
         }
         if let scrollViewConfigurator {
             view = view.scrollViewConfigurator(scrollViewConfigurator)

--- a/Sources/PDVideoPlayer/Common/Player/Extensions/RepresentableIOS.swift
+++ b/Sources/PDVideoPlayer/Common/Player/Extensions/RepresentableIOS.swift
@@ -3,15 +3,15 @@ import SwiftUI
 
 public extension PDVideoPlayerRepresentable {
     func scrollViewConfigurator(_ configurator: @escaping ScrollViewConfigurator) -> Self {
-        Self(model: self.model, panGesture: self.panGesture, scrollViewConfigurator: configurator, contextMenuProvider: self.contextMenuProvider, onTap: self.onTap)
+        Self(model: self.model, closeGesture: self.closeGesture, scrollViewConfigurator: configurator, contextMenuProvider: self.contextMenuProvider, onTap: self.onTap)
     }
 
     func contextMenuProvider(_ provider: @escaping ContextMenuProvider) -> Self {
-        Self(model: self.model, panGesture: self.panGesture, scrollViewConfigurator: self.scrollViewConfigurator, contextMenuProvider: provider, onTap: self.onTap)
+        Self(model: self.model, closeGesture: self.closeGesture, scrollViewConfigurator: self.scrollViewConfigurator, contextMenuProvider: provider, onTap: self.onTap)
     }
 
-    func panGesture(_ gesture: PDVideoPlayerPanGesture) -> Self {
-        Self(model: self.model, panGesture: gesture, scrollViewConfigurator: self.scrollViewConfigurator, contextMenuProvider: self.contextMenuProvider, onTap: self.onTap)
+    func closeGesture(_ gesture: PDVideoPlayerCloseGesture) -> Self {
+        Self(model: self.model, closeGesture: gesture, scrollViewConfigurator: self.scrollViewConfigurator, contextMenuProvider: self.contextMenuProvider, onTap: self.onTap)
     }
 }
 #endif

--- a/Sources/PDVideoPlayer/Common/Player/Extensions/TapAction.swift
+++ b/Sources/PDVideoPlayer/Common/Player/Extensions/TapAction.swift
@@ -4,7 +4,7 @@ public extension PDVideoPlayerRepresentable {
     func onTap(_ action: VideoPlayerTapAction) -> Self {
         #if os(iOS)
         Self(model: self.model,
-             panGesture: self.panGesture,
+             closeGesture: self.closeGesture,
              scrollViewConfigurator: self.scrollViewConfigurator,
              contextMenuProvider: self.contextMenuProvider,
              onTap: action)

--- a/Sources/PDVideoPlayer/Common/Player/PDVideoPlayerCloseGesture.swift
+++ b/Sources/PDVideoPlayer/Common/Player/PDVideoPlayerCloseGesture.swift
@@ -2,12 +2,12 @@ import Foundation
 
 #if os(iOS)
 /// Gesture types for closing the player.
-public enum PDVideoPlayerPanGesture {
+public enum PDVideoPlayerCloseGesture {
     /// Drag with rotation gesture.
     case rotation
     /// Drag only up and down.
     case vertical
-    /// Disable pan gesture.
+    /// Disable the close gesture.
     case none
 }
 #endif

--- a/Sources/PDVideoPlayer/Common/Player/VideoPlayerViewControllerRepresentable.swift
+++ b/Sources/PDVideoPlayer/Common/Player/VideoPlayerViewControllerRepresentable.swift
@@ -236,21 +236,21 @@ public struct PDVideoPlayerView_iOS: UIViewRepresentable {
 
     
     var model: PDPlayerModel
-    let panGesture: PDVideoPlayerPanGesture
+    let closeGesture: PDVideoPlayerCloseGesture
     let scrollViewConfigurator: ScrollViewConfigurator?
     let contextMenuProvider: ContextMenuProvider?
     let onTap: VideoPlayerTapAction?
  
     public init(
         model: PDPlayerModel,
-        panGesture: PDVideoPlayerPanGesture = .rotation,
+        closeGesture: PDVideoPlayerCloseGesture = .rotation,
         scrollViewConfigurator: ScrollViewConfigurator? = nil,
         contextMenuProvider: ContextMenuProvider? = nil,
         onTap: VideoPlayerTapAction? = nil
 
     ) {
         self.model = model
-        self.panGesture = panGesture
+        self.closeGesture = closeGesture
         self.scrollViewConfigurator = scrollViewConfigurator
         self.contextMenuProvider = contextMenuProvider
         self.onTap = onTap
@@ -337,7 +337,7 @@ public struct PDVideoPlayerView_iOS: UIViewRepresentable {
             let contextMenuInteraction = UIContextMenuInteraction(delegate: context.coordinator)
             playerView.view.addInteraction(contextMenuInteraction)
         }
-        switch panGesture {
+        switch closeGesture {
         case .rotation:
             let panGestureRecognizer = UIPanGestureRecognizer(target: model, action: #selector(PDPlayerModel.handlePanGesture(_:)))
             panGestureRecognizer.delegate = model

--- a/Sources/PDVideoPlayer/iOS/PDVideoPlayer_iOS.swift
+++ b/Sources/PDVideoPlayer/iOS/PDVideoPlayer_iOS.swift
@@ -19,7 +19,7 @@ public struct PDVideoPlayer<MenuContent: View, Content: View>: View {
     var foregroundColor: Color = .white
     var onClose: VideoPlayerCloseAction?
     var onLongPress: VideoPlayerLongpressAction?
-    var panGesture: PDVideoPlayerPanGesture = .rotation
+    var closeGesture: PDVideoPlayerCloseGesture = .rotation
 
     private let content: (PDVideoPlayerProxy<MenuContent>) -> Content
     private let menuContent: () -> MenuContent
@@ -53,7 +53,7 @@ public struct PDVideoPlayer<MenuContent: View, Content: View>: View {
             let proxy = PDVideoPlayerProxy(
                 player: PDVideoPlayerRepresentable(
                     model: model,
-                    panGesture: panGesture
+                    closeGesture: closeGesture
                 ),
                 control: VideoPlayerControlView(model: model, menuContent: menuContent),
                 navigation: VideoPlayerNavigationView()


### PR DESCRIPTION
## Summary
- rename panGesture modifier and related API to closeGesture
- update README and sample code to use closeGesture
- rename PDVideoPlayerPanGesture enum to PDVideoPlayerCloseGesture

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*