### PR TITLE
Enable presentation size callback on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ struct ContentView: View {
 - `isMuted(_:)` – Bind the mute state.
 - `onClose(_:)` – Handle closing the player.
 - `onLongPress(_:)` – Respond to long‑press gestures.
-- `onPresentationSizeChange(_:)` – Observe the presentation size on macOS.
+ - `onPresentationSizeChange(_:)` – Observe the presentation size on iOS and macOS.
 - `playerForegroundColor(_:)` – Set tint color for controls.
 - `panGesture(_:)` – Choose the pan gesture type on iOS.
 - `windowDraggable(_:)` – Allow dragging the macOS window by the player view.

--- a/Sources/PDVideoPlayer/Common/Player/Extensions/ProxyExtensions.swift
+++ b/Sources/PDVideoPlayer/Common/Player/Extensions/ProxyExtensions.swift
@@ -7,6 +7,7 @@ public extension PDVideoPlayerProxy {
         panGesture: PDVideoPlayerPanGesture? = nil,
         scrollViewConfigurator: PDVideoPlayerRepresentable.ScrollViewConfigurator? = nil,
         contextMenuProvider: PDVideoPlayerRepresentable.ContextMenuProvider? = nil,
+        onPresentationSizeChange: PDVideoPlayerRepresentable.PresentationSizeAction? = nil,
         onTap: VideoPlayerTapAction? = nil
     ) -> PDVideoPlayerRepresentable {
         var view = self.player
@@ -18,6 +19,9 @@ public extension PDVideoPlayerProxy {
         }
         if let contextMenuProvider {
             view = view.contextMenuProvider(contextMenuProvider)
+        }
+        if let onPresentationSizeChange {
+            view = view.onPresentationSizeChange(onPresentationSizeChange)
         }
         if let onTap {
             view = view.onTap(onTap)

--- a/Sources/PDVideoPlayer/Common/Player/Extensions/RepresentableIOS.swift
+++ b/Sources/PDVideoPlayer/Common/Player/Extensions/RepresentableIOS.swift
@@ -3,15 +3,39 @@ import SwiftUI
 
 public extension PDVideoPlayerRepresentable {
     func scrollViewConfigurator(_ configurator: @escaping ScrollViewConfigurator) -> Self {
-        Self(model: self.model, panGesture: self.panGesture, scrollViewConfigurator: configurator, contextMenuProvider: self.contextMenuProvider, onTap: self.onTap)
+        Self(model: self.model,
+             panGesture: self.panGesture,
+             scrollViewConfigurator: configurator,
+             contextMenuProvider: self.contextMenuProvider,
+             onPresentationSizeChange: self.onPresentationSizeChange,
+             onTap: self.onTap)
     }
 
     func contextMenuProvider(_ provider: @escaping ContextMenuProvider) -> Self {
-        Self(model: self.model, panGesture: self.panGesture, scrollViewConfigurator: self.scrollViewConfigurator, contextMenuProvider: provider, onTap: self.onTap)
+        Self(model: self.model,
+             panGesture: self.panGesture,
+             scrollViewConfigurator: self.scrollViewConfigurator,
+             contextMenuProvider: provider,
+             onPresentationSizeChange: self.onPresentationSizeChange,
+             onTap: self.onTap)
     }
 
     func panGesture(_ gesture: PDVideoPlayerPanGesture) -> Self {
-        Self(model: self.model, panGesture: gesture, scrollViewConfigurator: self.scrollViewConfigurator, contextMenuProvider: self.contextMenuProvider, onTap: self.onTap)
+        Self(model: self.model,
+             panGesture: gesture,
+             scrollViewConfigurator: self.scrollViewConfigurator,
+             contextMenuProvider: self.contextMenuProvider,
+             onPresentationSizeChange: self.onPresentationSizeChange,
+             onTap: self.onTap)
+    }
+
+    func onPresentationSizeChange(_ action: @escaping PresentationSizeAction) -> Self {
+        Self(model: self.model,
+             panGesture: self.panGesture,
+             scrollViewConfigurator: self.scrollViewConfigurator,
+             contextMenuProvider: self.contextMenuProvider,
+             onPresentationSizeChange: action,
+             onTap: self.onTap)
     }
 }
 #endif

--- a/Sources/PDVideoPlayer/Common/Player/Extensions/TapAction.swift
+++ b/Sources/PDVideoPlayer/Common/Player/Extensions/TapAction.swift
@@ -7,6 +7,7 @@ public extension PDVideoPlayerRepresentable {
              panGesture: self.panGesture,
              scrollViewConfigurator: self.scrollViewConfigurator,
              contextMenuProvider: self.contextMenuProvider,
+             onPresentationSizeChange: self.onPresentationSizeChange,
              onTap: action)
         #elseif os(macOS)
         Self(model: self.model,


### PR DESCRIPTION
## Summary
- add `onPresentationSizeChange` support for iOS
- expose callback through proxy helpers
- document cross-platform support

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*