### PR TITLE
Enable onPresentationSizeChange on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ struct ContentView: View {
 - `isMuted(_:)` – Bind the mute state.
 - `onClose(_:)` – Handle closing the player.
 - `onLongPress(_:)` – Respond to long‑press gestures.
-- `onPresentationSizeChange(_:)` – Observe the presentation size on macOS.
+- `onPresentationSizeChange(_:)` – Observe the presentation size.
 - `playerForegroundColor(_:)` – Set tint color for controls.
 - `closeGesture(_:)` – Choose the close gesture type on iOS.
 - `windowDraggable(_:)` – Allow dragging the macOS window by the player view.

--- a/Sources/PDVideoPlayer/Common/PDVideoPlayerSampleView.swift
+++ b/Sources/PDVideoPlayer/Common/PDVideoPlayerSampleView.swift
@@ -30,7 +30,7 @@ struct ContentView: View {
                         .onTap { inside in
                             print("onTap", inside)
                         }
-#if os(macOS)
+#if os(macOS) || os(iOS)
                         .onPresentationSizeChange({ view, size in
 
                         })

--- a/Sources/PDVideoPlayer/Common/Player/Extensions/RepresentableIOS.swift
+++ b/Sources/PDVideoPlayer/Common/Player/Extensions/RepresentableIOS.swift
@@ -3,15 +3,39 @@ import SwiftUI
 
 public extension PDVideoPlayerRepresentable {
     func scrollViewConfigurator(_ configurator: @escaping ScrollViewConfigurator) -> Self {
-        Self(model: self.model, closeGesture: self.closeGesture, scrollViewConfigurator: configurator, contextMenuProvider: self.contextMenuProvider, onTap: self.onTap)
+        Self(model: self.model,
+             closeGesture: self.closeGesture,
+             scrollViewConfigurator: configurator,
+             contextMenuProvider: self.contextMenuProvider,
+             onPresentationSizeChange: self.onPresentationSizeChange,
+             onTap: self.onTap)
     }
 
     func contextMenuProvider(_ provider: @escaping ContextMenuProvider) -> Self {
-        Self(model: self.model, closeGesture: self.closeGesture, scrollViewConfigurator: self.scrollViewConfigurator, contextMenuProvider: provider, onTap: self.onTap)
+        Self(model: self.model,
+             closeGesture: self.closeGesture,
+             scrollViewConfigurator: self.scrollViewConfigurator,
+             contextMenuProvider: provider,
+             onPresentationSizeChange: self.onPresentationSizeChange,
+             onTap: self.onTap)
     }
 
     func closeGesture(_ gesture: PDVideoPlayerCloseGesture) -> Self {
-        Self(model: self.model, closeGesture: gesture, scrollViewConfigurator: self.scrollViewConfigurator, contextMenuProvider: self.contextMenuProvider, onTap: self.onTap)
+        Self(model: self.model,
+             closeGesture: gesture,
+             scrollViewConfigurator: self.scrollViewConfigurator,
+             contextMenuProvider: self.contextMenuProvider,
+             onPresentationSizeChange: self.onPresentationSizeChange,
+             onTap: self.onTap)
+    }
+
+    func onPresentationSizeChange(_ action: @escaping PresentationSizeAction) -> Self {
+        Self(model: self.model,
+             closeGesture: self.closeGesture,
+             scrollViewConfigurator: self.scrollViewConfigurator,
+             contextMenuProvider: self.contextMenuProvider,
+             onPresentationSizeChange: action,
+             onTap: self.onTap)
     }
 }
 #endif

--- a/Sources/PDVideoPlayer/Common/Player/Extensions/TapAction.swift
+++ b/Sources/PDVideoPlayer/Common/Player/Extensions/TapAction.swift
@@ -7,6 +7,7 @@ public extension PDVideoPlayerRepresentable {
              closeGesture: self.closeGesture,
              scrollViewConfigurator: self.scrollViewConfigurator,
              contextMenuProvider: self.contextMenuProvider,
+             onPresentationSizeChange: self.onPresentationSizeChange,
              onTap: action)
         #elseif os(macOS)
         Self(model: self.model,


### PR DESCRIPTION
## Summary
- expose onPresentationSizeChange modifier on iOS
- wire up presentation size observation in the iOS representable
- update sample view and README to mention iOS support
- clean up README wording

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*