### PR TITLE
Clarify ripple animation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - Universal support for **iOS** and **macOS** using the same code base.
 - Picture-in-Picture on iOS via `PiPManager`.
 - AirPlay route picker for streaming to external displays.
+- Custom context menus on iOS via `contextMenuProvider`.
 - Gesture handling including double-tap skip with ripple effects, long press speed changes, and optional close gestures for rotation or vertical seeking.
 - Customizable keyboard shortcuts for quick navigation.
 - Environment driven configuration such as mute state, close actions, long‑press callbacks and foreground color.
@@ -62,6 +63,7 @@ struct ContentView: View {
                         )
                     }
                     .skipRippleEffect()
+                        // adds a ripple animation when double‑tap skipping
 #endif
 #if os(macOS)
                     .onPresentationSizeChange({ view, size in
@@ -100,6 +102,8 @@ struct ContentView: View {
 - `playerForegroundColor(_:)` – Set tint color for controls.
 - `closeGesture(_:)` – Choose the close gesture type on iOS.
 - `windowDraggable(_:)` – Allow dragging the macOS window by the player view.
+- `contextMenuProvider(_:)` – Provide a custom context menu for a tap location on iOS.
+- `skipRippleEffect()` – Show a ripple animation when double‑tap skipping on iOS.
 
 ## License
 

--- a/Sources/PDVideoPlayer/Common/Player/PDPlayerModel.swift
+++ b/Sources/PDVideoPlayer/Common/Player/PDPlayerModel.swift
@@ -59,7 +59,7 @@ enum SkipDirection {
         // ダブルタップの方向を判定 (左: 巻き戻し, 右: 早送り)
         let newDirection: SkipDirection = (tapX < viewWidth / 2) ? .backward : .forward
         
-        // もし方向が変わったらリセットする (YouTube の挙動を想定)
+        // Reset if the direction changes to mimic common video app behavior
         if doubleTapDirection != newDirection {
             // 新たに連続ダブルタップを開始
             doubleTapCount = 0


### PR DESCRIPTION
## Summary
- document `contextMenuProvider` in features
- explain `.skipRippleEffect()` shows a ripple animation
- comment out YouTube reference in player model

## Testing
- `swift test -v` *(fails: no such module 'SwiftUI')*