### PR TITLE
Add trackpad overlay for macOS controls

### DIFF
--- a/Sources/PDVideoPlayer/Common/Slider/VideoPlayerSlider.swift
+++ b/Sources/PDVideoPlayer/Common/Slider/VideoPlayerSlider.swift
@@ -88,8 +88,7 @@ class VideoPlayerSlider: NSSlider {
         set { (cell as? VideoPlayerSliderCell)?.baseColor = newValue }
     }
     override var intrinsicContentSize: NSSize {
-        let s = super.intrinsicContentSize
-        return NSSize(width: s.width, height: s.height + 40)
+        super.intrinsicContentSize
     }
     var onScroll: ((NSEvent.Phase, Double) -> Void)?
 


### PR DESCRIPTION
## Summary
- support trackpad swipes on macOS with a new overlay
- no longer inflate slider intrinsic content size on macOS

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*