### PR TITLE
Refactor trackpad overlay

### DIFF
--- a/Sources/PDVideoPlayer/Common/TrackpadSwipeOverlay.swift
+++ b/Sources/PDVideoPlayer/Common/TrackpadSwipeOverlay.swift
@@ -1,0 +1,66 @@
+#if os(macOS)
+import SwiftUI
+
+private final class PassThroughView: NSView {
+    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+}
+
+struct TrackpadSwipeOverlay: NSViewRepresentable {
+    var model: PDPlayerModel
+
+    @MainActor
+    final class Coordinator {
+        var model: PDPlayerModel
+        weak var overlay: NSView?
+        var monitor: Any?
+
+        init(model: PDPlayerModel) { self.model = model }
+
+        func startMonitoring() {
+            monitor = NSEvent.addLocalMonitorForEvents(matching: .scrollWheel) { [weak self] event in
+                guard
+                    let self,
+                    let view = self.overlay,
+                    view.window != nil
+                else { return event }
+
+                let local = view.convert(event.locationInWindow, from: nil)
+
+                if view.bounds.contains(local),
+                   abs(event.scrollingDeltaX) > abs(event.scrollingDeltaY) {
+                    self.model.slider.scrollWheel(with: event)
+                    return nil
+                }
+                return event
+            }
+        }
+
+        func stopMonitoring() {
+            if let monitor { NSEvent.removeMonitor(monitor) }
+            monitor = nil
+        }
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator(model: model) }
+
+    func makeNSView(context: Context) -> NSView {
+        let v = PassThroughView()
+        context.coordinator.overlay = v
+        context.coordinator.startMonitoring()
+        return v
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {}
+
+    static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
+        coordinator.stopMonitoring()
+    }
+}
+
+public extension View {
+    /// Enables trackpad swipe seeking using the provided player model.
+    func trackpadSeeking(_ model: PDPlayerModel) -> some View {
+        overlay(TrackpadSwipeOverlay(model: model))
+    }
+}
+#endif

--- a/Sources/PDVideoPlayer/Common/VideoPlayerControlView.swift
+++ b/Sources/PDVideoPlayer/Common/VideoPlayerControlView.swift
@@ -40,67 +40,10 @@ public struct VideoPlayerControlView<MenuContent: View>: View {
             VideoPlayerSliderView(viewModel: model)
         }
         .contentShape(Rectangle())
-        .overlay(
-            TrackpadSwipeOverlay(model: model)
-        )
+        .trackpadSeeking(model)
     }
 }
 
-final class PassThroughView: NSView {
-    override func hitTest(_ point: NSPoint) -> NSView? { nil }
-}
-
-struct TrackpadSwipeOverlay: NSViewRepresentable {
-    var model: PDPlayerModel
-
-    @MainActor
-    final class Coordinator {
-        var model: PDPlayerModel
-        weak var overlay: NSView?
-        var monitor: Any?
-
-        init(model: PDPlayerModel) { self.model = model }
-
-        func startMonitoring() {
-            monitor = NSEvent.addLocalMonitorForEvents(matching: .scrollWheel) { [weak self] event in
-                guard
-                    let self,
-                    let view = self.overlay,
-                    view.window != nil
-                else { return event }
-
-                let local = view.convert(event.locationInWindow, from: nil)
-
-                if view.bounds.contains(local),
-                   abs(event.scrollingDeltaX) > abs(event.scrollingDeltaY) {
-                    self.model.slider.scrollWheel(with: event)
-                    return nil
-                }
-                return event
-            }
-        }
-
-        func stopMonitoring() {
-            if let monitor { NSEvent.removeMonitor(monitor) }
-            monitor = nil
-        }
-    }
-
-    func makeCoordinator() -> Coordinator { Coordinator(model: model) }
-
-    func makeNSView(context: Context) -> NSView {
-        let v = PassThroughView()
-        context.coordinator.overlay = v
-        context.coordinator.startMonitoring()
-        return v
-    }
-
-    func updateNSView(_ nsView: NSView, context: Context) {}
-
-    static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
-        coordinator.stopMonitoring()
-    }
-}
 #else
 public struct VideoPlayerControlView<MenuContent: View>: View {
     var model: PDPlayerModel


### PR DESCRIPTION
## Summary
- move `TrackpadSwipeOverlay` into its own file
- expose the overlay through a `trackpadSeeking` view extension

## Testing
- `swift test -l` *(fails: no such module 'SwiftUI')*