### PR TITLE
Rename trackpadSeeking extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - AirPlay route picker for streaming to external displays.
 - Custom context menus on iOS via `contextMenuProvider`.
 - Gesture handling including double-tap skip with ripple effects, long press speed changes, and optional close gestures for rotation or vertical seeking.
+- Optional overlay to enlarge the trackpad swipe seeking area on macOS.
 - Customizable keyboard shortcuts for quick navigation.
 - Environment driven configuration such as mute state, close actions, long‑press callbacks and foreground color.
 - Built using pure SwiftUI with minimal dependencies.
@@ -89,6 +90,7 @@ struct ContentView: View {
 - `windowDraggable(_:)` – Allow dragging the macOS window by the player view.
 - `contextMenuProvider(_:)` – Provide a custom context menu for a tap location on iOS.
 - `skipRippleEffect()` – Show a ripple animation when double‑tap skipping on iOS.
+- `trackpadSwipeOverlay()` – Expand the area for trackpad swipe seeking on macOS.
 
 ## License
 

--- a/Sources/PDVideoPlayer/Common/PDVideoPlayerSampleView.swift
+++ b/Sources/PDVideoPlayer/Common/PDVideoPlayerSampleView.swift
@@ -58,7 +58,7 @@ struct ContentView: View {
                             proxy.navigation
                             Spacer()
                             proxy.control
-                                .trackpadSeeking()
+                                .trackpadSwipeOverlay()
 #if os(macOS)
                                 .buttonStyle(.plain)
                                 .padding(.horizontal)

--- a/Sources/PDVideoPlayer/macOS/TrackpadSwipeOverlay.swift
+++ b/Sources/PDVideoPlayer/macOS/TrackpadSwipeOverlay.swift
@@ -57,8 +57,9 @@ struct TrackpadSwipeOverlay: NSViewRepresentable {
 }
 
 public extension View {
-    /// Enables trackpad swipe seeking using the provided player model.
-    func trackpadSeeking() -> some View {
+    /// Places an invisible overlay to enlarge the trackpad swipe area
+    /// for scrubbing with two fingers.
+    func trackpadSwipeOverlay() -> some View {
         overlay(TrackpadSwipeOverlay())
     }
 }


### PR DESCRIPTION
## Summary
- rename `trackpadSeeking` modifier to `trackpadSwipeOverlay`
- update sample code to use the new modifier
- document optional overlay for macOS trackpad seeking in README

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*