### PR TITLE
Fix missing UIGestureRecognizerDelegate conformance

### DIFF
--- a/Sources/PDVideoPlayer/Common/Player/PDPlayerModel.swift
+++ b/Sources/PDVideoPlayer/Common/Player/PDPlayerModel.swift
@@ -418,6 +418,10 @@ extension UIView {
 }
 #endif
 
+#if os(iOS)
+extension PDPlayerModel: UIGestureRecognizerDelegate {}
+#endif
+
 extension PDPlayerModel {
     public func loadSubtitleOptions() async {
         guard let item = player.currentItem else { return }

--- a/Sources/PDVideoPlayer/Common/Player/VideoPlayerViewControllerRepresentable.swift
+++ b/Sources/PDVideoPlayer/Common/Player/VideoPlayerViewControllerRepresentable.swift
@@ -359,12 +359,12 @@ public struct PDVideoPlayerView_iOS: UIViewRepresentable {
         switch closeGesture {
         case .rotation:
             let panGestureRecognizer = UIPanGestureRecognizer(target: model, action: #selector(PDPlayerModel.handlePanGesture(_:)))
-            panGestureRecognizer.delegate = context.coordinator
+            panGestureRecognizer.delegate = model
             scrollView.isUserInteractionEnabled = true
             scrollView.addGestureRecognizer(panGestureRecognizer)
         case .vertical:
             let panGestureRecognizer = UIPanGestureRecognizer(target: model, action: #selector(PDPlayerModel.handlePanGestureUpDown(_:)))
-            panGestureRecognizer.delegate = context.coordinator
+            panGestureRecognizer.delegate = model
             scrollView.isUserInteractionEnabled = true
             scrollView.addGestureRecognizer(panGestureRecognizer)
         case .none:


### PR DESCRIPTION
## Summary
- make `PDPlayerModel` conform to `UIGestureRecognizerDelegate`

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*