### PR TITLE
Maintain double speed when timeControlStatus changes

### DIFF
--- a/Sources/PDVideoPlayer/Common/Player/PDPlayerModel.swift
+++ b/Sources/PDVideoPlayer/Common/Player/PDPlayerModel.swift
@@ -78,6 +78,9 @@ public class PDPlayerModel: NSObject, DynamicProperty {
                 case .playing:
                     self.addPeriodicTimeObserver()
                     if !self.isPlaying { self.isPlaying = true }
+                    if self.isLongpress {
+                        self.player.rate = min(self.originalRate * 2.0, 2.0)
+                    }
                     if self.isBuffering { self.isBuffering = false }
                 case .paused:
                     self.removePeriodicTimeObserver()


### PR DESCRIPTION
## Summary
- restore doubled rate when status changes to `.playing`
- remove redundant check in `play()`

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*