### PR TITLE
Enable scrollView configurator on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ struct ContentView: View {
 - `playerForegroundColor(_:)` – Set tint color for controls.
 - `windowDraggable(_:)` – Allow dragging the macOS window by the player view.
 - `contextMenuProvider(_:)` – Provide a custom context menu for a tap location on iOS.
-- `scrollViewConfigurator(_:)` – Customize the underlying `UIScrollView` on iOS.
+- `scrollViewConfigurator(_:)` – Customize the underlying scroll view.
 - `skipRippleEffect()` – Show a ripple animation when double‑tap skipping on iOS.
 - `trackpadSwipeOverlay()` – Expand the area for trackpad swipe seeking on macOS.
 

--- a/Sources/PDVideoPlayer/Common/Player/Extensions/ProxyExtensions.swift
+++ b/Sources/PDVideoPlayer/Common/Player/Extensions/ProxyExtensions.swift
@@ -21,4 +21,27 @@ public extension PDVideoPlayerProxy {
         return view
     }
 }
+#elseif os(macOS)
+import SwiftUI
+
+@MainActor
+public extension PDVideoPlayerProxy {
+    func player(
+        scrollViewConfigurator: PDVideoPlayerRepresentable.ScrollViewConfigurator? = nil,
+        playerViewConfigurator: PDVideoPlayerRepresentable.PlayerViewConfigurator? = nil,
+        onTap: VideoPlayerTapAction? = nil
+    ) -> PDVideoPlayerRepresentable {
+        var view = self.player
+        if let scrollViewConfigurator {
+            view = view.scrollViewConfigurator(scrollViewConfigurator)
+        }
+        if let playerViewConfigurator {
+            view = view.playerViewConfigurator(playerViewConfigurator)
+        }
+        if let onTap {
+            view = view.onTap(onTap)
+        }
+        return view
+    }
+}
 #endif

--- a/Sources/PDVideoPlayer/Common/Player/Extensions/RepresentableMac.swift
+++ b/Sources/PDVideoPlayer/Common/Player/Extensions/RepresentableMac.swift
@@ -2,12 +2,31 @@
 import SwiftUI
 
 public extension PDVideoPlayerRepresentable {
+    func scrollViewConfigurator(_ configurator: @escaping ScrollViewConfigurator) -> Self {
+        Self(model: self.model,
+             scrollViewConfigurator: configurator,
+             playerViewConfigurator: self.playerViewConfigurator,
+             onPresentationSizeChange: self.onPresentationSizeChange,
+             onTap: self.onTap,
+             menuContent: self.menuContent)
+    }
+
     func playerViewConfigurator(_ configurator: @escaping PlayerViewConfigurator) -> Self {
-        Self(model: self.model, playerViewConfigurator: configurator, onPresentationSizeChange: self.onPresentationSizeChange, onTap: self.onTap, menuContent: self.menuContent)
+        Self(model: self.model,
+             scrollViewConfigurator: self.scrollViewConfigurator,
+             playerViewConfigurator: configurator,
+             onPresentationSizeChange: self.onPresentationSizeChange,
+             onTap: self.onTap,
+             menuContent: self.menuContent)
     }
 
     func onPresentationSizeChange(_ action: @escaping PresentationSizeAction) -> Self {
-        Self(model: self.model, playerViewConfigurator: self.playerViewConfigurator, onPresentationSizeChange: action, onTap: self.onTap, menuContent: self.menuContent)
+        Self(model: self.model,
+             scrollViewConfigurator: self.scrollViewConfigurator,
+             playerViewConfigurator: self.playerViewConfigurator,
+             onPresentationSizeChange: action,
+             onTap: self.onTap,
+             menuContent: self.menuContent)
     }
 }
 #endif

--- a/Sources/PDVideoPlayer/Common/Player/Extensions/TapAction.swift
+++ b/Sources/PDVideoPlayer/Common/Player/Extensions/TapAction.swift
@@ -10,6 +10,7 @@ public extension PDVideoPlayerRepresentable {
              onTap: action)
         #elseif os(macOS)
         Self(model: self.model,
+             scrollViewConfigurator: self.scrollViewConfigurator,
              playerViewConfigurator: self.playerViewConfigurator,
              onPresentationSizeChange: self.onPresentationSizeChange,
              onTap: action,

--- a/Sources/PDVideoPlayer/Common/Player/VideoPlayerViewControllerRepresentable.swift
+++ b/Sources/PDVideoPlayer/Common/Player/VideoPlayerViewControllerRepresentable.swift
@@ -21,27 +21,31 @@ public typealias PDVideoPlayerRepresentable = PDVideoPlayerView_macOS
 public struct PDVideoPlayerView_macOS<MenuContent: View>: NSViewRepresentable {
     public typealias ContextMenuProvider = (CGPoint) -> NSMenu?
     public typealias PlayerViewConfigurator = (PlayerNSView) -> Void
+    public typealias ScrollViewConfigurator = (NSScrollView) -> Void
     public typealias PresentationSizeAction = ((_ view: NSView, _ size: CGSize) -> Void)
-    
+
     var model: PDPlayerModel
     let menuContent: () -> MenuContent
     let onPresentationSizeChange: PresentationSizeAction?
+    let scrollViewConfigurator: ScrollViewConfigurator?
     let playerViewConfigurator: PlayerViewConfigurator?
     let onTap: VideoPlayerTapAction?
     
     public init(
         model: PDPlayerModel,
-        playerViewConfigurator:PlayerViewConfigurator? = nil,
+        scrollViewConfigurator: ScrollViewConfigurator? = nil,
+        playerViewConfigurator: PlayerViewConfigurator? = nil,
         onPresentationSizeChange: PresentationSizeAction? = nil,
         onTap: VideoPlayerTapAction? = nil,
         @ViewBuilder menuContent: @escaping () -> MenuContent
     ) {
         self.model = model
+        self.scrollViewConfigurator = scrollViewConfigurator
         self.playerViewConfigurator = playerViewConfigurator
         self.menuContent = menuContent
         self.onPresentationSizeChange = onPresentationSizeChange
         self.onTap = onTap
-        
+
     }
     
     @Environment(\.videoPlayerOnLongPress) private var onLongPress
@@ -121,6 +125,8 @@ public struct PDVideoPlayerView_macOS<MenuContent: View>: NSViewRepresentable {
         scrollView.hasVerticalScroller = false
         scrollView.hasHorizontalScroller = false
         scrollView.drawsBackground = false
+
+        scrollViewConfigurator?(scrollView)
 
 
         if #available(macOS 14.4, *) {


### PR DESCRIPTION
## Summary
- extend `PDVideoPlayerView_macOS` with a `scrollViewConfigurator` hook
- provide macOS APIs for configuring the underlying `NSScrollView`
- update proxy and tap action helpers to pass the new value
- document cross-platform support in the README
- simplify the README bullet for `scrollViewConfigurator`

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*