### PR TITLE
Fix generic return type for macOS player extension

### DIFF
--- a/Sources/PDVideoPlayer/Common/Player/Extensions/ProxyExtensions.swift
+++ b/Sources/PDVideoPlayer/Common/Player/Extensions/ProxyExtensions.swift
@@ -27,10 +27,10 @@ import SwiftUI
 @MainActor
 public extension PDVideoPlayerProxy {
     func player(
-        scrollViewConfigurator: PDVideoPlayerRepresentable.ScrollViewConfigurator? = nil,
-        playerViewConfigurator: PDVideoPlayerRepresentable.PlayerViewConfigurator? = nil,
+        scrollViewConfigurator: PDVideoPlayerRepresentable<PlayerMenu>.ScrollViewConfigurator? = nil,
+        playerViewConfigurator: PDVideoPlayerRepresentable<PlayerMenu>.PlayerViewConfigurator? = nil,
         onTap: VideoPlayerTapAction? = nil
-    ) -> PDVideoPlayerRepresentable {
+    ) -> PDVideoPlayerRepresentable<PlayerMenu> {
         var view = self.player
         if let scrollViewConfigurator {
             view = view.scrollViewConfigurator(scrollViewConfigurator)


### PR DESCRIPTION
## Summary
- update macOS `PDVideoPlayerProxy.player` method to specify the `PlayerMenu` generic for `PDVideoPlayerRepresentable`

## Testing
- `swift test -l` *(fails: no such module 'SwiftUI')*