### PR TITLE
Update player model to support replacement

### DIFF
--- a/Sources/PDVideoPlayer/iOS/PDVideoPlayer_iOS.swift
+++ b/Sources/PDVideoPlayer/iOS/PDVideoPlayer_iOS.swift
@@ -104,11 +104,17 @@ public struct PDVideoPlayer<MenuContent: View, Content: View>: View {
         url:URL?,
         player:AVPlayer?
     ){
-        if let url{
+        if let model {
+            if let url {
+                model.replacePlayer(url: url)
+            } else if let player {
+                model.replacePlayer(with: player)
+            }
+        } else if let url {
             let newModel = PDPlayerModel(url: url)
             newModel.onClose = onClose
             model = newModel
-        }else if let player{
+        } else if let player {
             let newModel = PDPlayerModel(player: player)
             newModel.onClose = onClose
             model = newModel

--- a/Sources/PDVideoPlayer/macOS/PDVideoPlayer_macOS.swift
+++ b/Sources/PDVideoPlayer/macOS/PDVideoPlayer_macOS.swift
@@ -98,12 +98,18 @@ public struct PDVideoPlayer<PlayerMenu: View,
         url:URL?,
         player:AVPlayer?
     ){
-        if let url{
+        if let model {
+            if let url {
+                model.replacePlayer(url: url)
+            } else if let player {
+                model.replacePlayer(with: player)
+            }
+        } else if let url {
             let m = PDPlayerModel(url: url)
             m.onClose = onClose
             m.windowDraggable = windowDraggable
             model = m
-        }else if let player{
+        } else if let player {
             let m = PDPlayerModel(player: player)
             m.onClose = onClose
             m.windowDraggable = windowDraggable


### PR DESCRIPTION
## Summary
- add `replacePlayer` API to `PDPlayerModel`
- observe player status with new helper and update existing setup functions
- modify `PDVideoPlayer` views to reuse the model and only replace the underlying `AVPlayer`

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*