### PR TITLE
Improve subtitle loading

### DIFF
--- a/Sources/PDVideoPlayer/Common/SubtitleMenuView.swift
+++ b/Sources/PDVideoPlayer/Common/SubtitleMenuView.swift
@@ -19,7 +19,6 @@ public struct SubtitleMenuView: View {
             Label(String(localized: "Subtitles"), systemImage: "captions.bubble")
                 .symbolVariant(model.selectedSubtitle == nil ? .none : .fill)
         }
-        .task{ await model.loadSubtitleOptions() }
     }
 }
 #endif


### PR DESCRIPTION
## Summary
- observe AVPlayerItem status so subtitles are reloaded once the item becomes ready
- remove unused subtitle loading task from `SubtitleMenuView`

## Testing
- `swift test -l` *(fails: no such module 'SwiftUI')*