### PR TITLE
Refactor constraint helper

### DIFF
--- a/Sources/PDVideoPlayer/Common/Player/Extensions/PlatformView+ScaledConstraints.swift
+++ b/Sources/PDVideoPlayer/Common/Player/Extensions/PlatformView+ScaledConstraints.swift
@@ -1,0 +1,36 @@
+#if canImport(UIKit)
+typealias PlatformView = UIView
+#elseif canImport(AppKit)
+typealias PlatformView = NSView
+#endif
+
+extension PlatformView {
+    /// Constrain the view to fit inside its container while preserving aspect ratio.
+    /// - Parameters:
+    ///   - container: The container view to fit within.
+    ///   - contentSize: The natural size of the content for calculating aspect ratio.
+    func setConstraintScalledToFit(
+        container containerView: PlatformView,
+        size contentSize: CGSize
+    ) {
+        containerView.constraints.forEach { $0.isActive = false }
+        NSLayoutConstraint.activate([
+            self.centerXAnchor.constraint(equalTo: containerView.centerXAnchor),
+            self.centerYAnchor.constraint(equalTo: containerView.centerYAnchor)
+        ])
+
+        let widthLimit  = self.widthAnchor.constraint(lessThanOrEqualTo: containerView.widthAnchor)
+        let heightLimit = self.heightAnchor.constraint(lessThanOrEqualTo: containerView.heightAnchor)
+        NSLayoutConstraint.activate([widthLimit, heightLimit])
+
+        let aspectRatio = contentSize.width / contentSize.height
+        let aspect = self.widthAnchor.constraint(equalTo: self.heightAnchor, multiplier: aspectRatio)
+        NSLayoutConstraint.activate([aspect])
+
+        let widthEqual = self.widthAnchor.constraint(equalTo: containerView.widthAnchor)
+        widthEqual.priority = .defaultLow
+        let heightEqual = self.heightAnchor.constraint(equalTo: containerView.heightAnchor)
+        heightEqual.priority = .defaultLow
+        NSLayoutConstraint.activate([widthEqual, heightEqual])
+    }
+}

--- a/Sources/PDVideoPlayer/Common/Player/VideoPlayerViewControllerRepresentable.swift
+++ b/Sources/PDVideoPlayer/Common/Player/VideoPlayerViewControllerRepresentable.swift
@@ -12,42 +12,7 @@ import AVKit
 import AppKit
 #endif
 
-#if canImport(UIKit)
-typealias PlatformView = UIView
-#elseif canImport(AppKit)
-typealias PlatformView = NSView
-#endif
-extension PlatformView{
-    func setConstraintScalledToFit(
-        container containerView: PlatformView,
-        size contentSize: CGSize
-    ) {
-        containerView.constraints.forEach { $0.isActive = false }
-        // Center the image view within the container
-        NSLayoutConstraint.activate([
-            self.centerXAnchor.constraint(equalTo: containerView.centerXAnchor),
-            self.centerYAnchor.constraint(equalTo: containerView.centerYAnchor)
-        ])
 
-        // Limit the size so the image never exceeds the container
-        let widthLimit  = self.widthAnchor.constraint(lessThanOrEqualTo: containerView.widthAnchor)
-        let heightLimit = self.heightAnchor.constraint(lessThanOrEqualTo: containerView.heightAnchor)
-        NSLayoutConstraint.activate([widthLimit, heightLimit])
-
-        // Maintain the aspect ratio
-        let aspectRatio = contentSize.width / contentSize.height
-        let aspect = self.widthAnchor.constraint(equalTo: self.heightAnchor, multiplier: aspectRatio)
-        NSLayoutConstraint.activate([aspect])
-
-        // Provide low priority equality constraints so Auto Layout can
-        // choose the dimension that best fits the current orientation.
-        let widthEqual = self.widthAnchor.constraint(equalTo: containerView.widthAnchor)
-        widthEqual.priority = .defaultLow
-        let heightEqual = self.heightAnchor.constraint(equalTo: containerView.heightAnchor)
-        heightEqual.priority = .defaultLow
-        NSLayoutConstraint.activate([widthEqual, heightEqual])
-    }
-}
 
 
 


### PR DESCRIPTION
## Summary
- extract `setConstraintScalledToFit` to its own extension file
- keep `VideoPlayerViewControllerRepresentable` focused on representable logic

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*