### PR TITLE
Implement pinch-to-fill on iOS

### DIFF
--- a/Sources/PDVideoPlayer/Common/Player/PDPlayerModel.swift
+++ b/Sources/PDVideoPlayer/Common/Player/PDPlayerModel.swift
@@ -39,6 +39,8 @@ public class PDPlayerModel: NSObject, DynamicProperty {
     public var scrollView = UIScrollView()
     private var playerVC: AVPlayerViewController?
     public var isLongpress: Bool = false
+    /// When true the player should ignore safe area insets to fill the screen.
+    public var isZoomedToFill: Bool = false
 #elseif os(macOS)
     /// When true, dragging on the player view moves the window.
     public var windowDraggable: Bool = false

--- a/Sources/PDVideoPlayer/iOS/PDVideoPlayer_iOS.swift
+++ b/Sources/PDVideoPlayer/iOS/PDVideoPlayer_iOS.swift
@@ -3,7 +3,11 @@ import SwiftUI
 import AVKit
 
 public struct PDVideoPlayerProxy<MenuContent: View> {
-    public let player:  PDVideoPlayerRepresentable
+    var model: PDPlayerModel
+    public var player: some View {
+        PDVideoPlayerRepresentable(model: model)
+            .ignoresSafeArea(model.isZoomedToFill ? .all : [])
+    }
     public let control: VideoPlayerControlView<MenuContent>
     public let navigation: VideoPlayerNavigationView
 }
@@ -50,9 +54,7 @@ public struct PDVideoPlayer<MenuContent: View, Content: View>: View {
     public var body: some View {
         if let model {
             let proxy = PDVideoPlayerProxy(
-                player: PDVideoPlayerRepresentable(
-                    model: model
-                ),
+                model: model,
                 control: VideoPlayerControlView(model: model, menuContent: menuContent),
                 navigation: VideoPlayerNavigationView()
             )


### PR DESCRIPTION
## Summary
- track whether zoom fills the screen on iPhone
- expose player view that ignores safe areas when zoomed
- compute max zoom scale in the iOS player and update zoom state
- snap the zoom scale to fill when the gesture ends near the fill size

## Testing
- `swift test -v --disable-sandbox` *(fails: no such module 'SwiftUI')*