### PR TITLE
Add playback speed menu

### DIFF
--- a/Sources/PDVideoPlayer/Common/PDVideoPlayerExtensions.swift
+++ b/Sources/PDVideoPlayer/Common/PDVideoPlayerExtensions.swift
@@ -7,6 +7,12 @@ public extension PDVideoPlayer {
         copy.isMuted = binding
         return copy
     }
+
+    func playbackSpeed(_ binding: Binding<PlaybackSpeed>) -> Self {
+        var copy = self
+        copy.playbackSpeed = binding
+        return copy
+    }
     
     func onClose(_ action: VideoPlayerCloseAction) -> Self {
         var copy = self

--- a/Sources/PDVideoPlayer/Common/PDVideoPlayerSampleView.swift
+++ b/Sources/PDVideoPlayer/Common/PDVideoPlayerSampleView.swift
@@ -9,6 +9,7 @@ private let sampleURL = URL(fileURLWithPath: "/Users/kn/Downloads/ScreenRecordin
 struct ContentView: View {
     @State private var isMuted: Bool = true
     @State private var controlsVisible: Bool = true
+    @State private var speed: PlaybackSpeed = .x1_0
     
     var body: some View {
         PDVideoPlayer(
@@ -72,6 +73,7 @@ struct ContentView: View {
             }
         )
         .isMuted($isMuted)
+        .playbackSpeed($speed)
         .onLongPress { value in
             print("onLongPress", value)
         }

--- a/Sources/PDVideoPlayer/Common/PlaybackSpeed.swift
+++ b/Sources/PDVideoPlayer/Common/PlaybackSpeed.swift
@@ -1,0 +1,36 @@
+#if os(iOS) || os(macOS)
+import Foundation
+
+/// Supported playback speeds for the video player.
+public enum PlaybackSpeed: String, CaseIterable, Identifiable {
+    case x0_5
+    case x1_0
+    case x1_25
+    case x1_5
+    case x2_0
+
+    public var id: String { rawValue }
+
+    /// Numeric rate value associated with the speed.
+    public var value: Float {
+        switch self {
+        case .x0_5: return 0.5
+        case .x1_0: return 1.0
+        case .x1_25: return 1.25
+        case .x1_5: return 1.5
+        case .x2_0: return 2.0
+        }
+    }
+
+    /// Display string used by menu views.
+    public var displayName: String {
+        switch self {
+        case .x0_5: return "0.5x"
+        case .x1_0: return "1.0x"
+        case .x1_25: return "1.25x"
+        case .x1_5: return "1.5x"
+        case .x2_0: return "2.0x"
+        }
+    }
+}
+#endif

--- a/Sources/PDVideoPlayer/Common/PlaybackSpeedMenuView.swift
+++ b/Sources/PDVideoPlayer/Common/PlaybackSpeedMenuView.swift
@@ -1,0 +1,21 @@
+#if os(iOS) || os(macOS)
+import SwiftUI
+
+/// A menu allowing selection of playback speed.
+public struct PlaybackSpeedMenuView: View {
+    @Environment(PDPlayerModel.self) private var model
+    @Environment(\.videoPlayerPlaybackSpeed) private var speedBinding
+
+    public init() {}
+
+    public var body: some View {
+        Picker(selection: speedBinding ?? Bindable(model).playbackSpeed) {
+            ForEach(PlaybackSpeed.allCases) { speed in
+                Text(speed.displayName).tag(speed)
+            }
+        } label: {
+            Label("Speed", systemImage: "speedometer")
+        }
+    }
+}
+#endif

--- a/Sources/PDVideoPlayer/Common/Player/PDPlayerModel.swift
+++ b/Sources/PDVideoPlayer/Common/Player/PDPlayerModel.swift
@@ -28,6 +28,14 @@ public class PDPlayerModel: NSObject, DynamicProperty {
     public var player: AVPlayer
     public var onClose: VideoPlayerCloseAction?
     public var originalRate: Float = 1.0
+    public var playbackSpeed: PlaybackSpeed = .x1_0 {
+        didSet {
+            originalRate = playbackSpeed.value
+            if isPlaying {
+                player.rate = playbackSpeed.value
+            }
+        }
+    }
 
 #if os(iOS)
     public var isLooping: Bool = true
@@ -71,6 +79,7 @@ public class PDPlayerModel: NSObject, DynamicProperty {
 #elseif os(macOS)
         playerView?.setPlayer(newPlayer, videoGravity: .resizeAspect)
 #endif
+        newPlayer.rate = playbackSpeed.value
         newPlayer.appliesMediaSelectionCriteriaAutomatically = false
         observePlayerStatus()
         observeSubtitleUpdates()
@@ -206,6 +215,7 @@ public class PDPlayerModel: NSObject, DynamicProperty {
             seek(to: 0)
         }
         player.play()
+        player.rate = playbackSpeed.value
     }
 
     func pause() { player.pause() }

--- a/Sources/PDVideoPlayer/Common/VideoPlayerControlView.swift
+++ b/Sources/PDVideoPlayer/Common/VideoPlayerControlView.swift
@@ -30,6 +30,7 @@ public struct VideoPlayerControlView<MenuContent: View>: View {
                 VideoPlayerDurationView(model:model)
                 Menu{
                     SubtitleMenuView()
+                    PlaybackSpeedMenuView()
                     Divider()
                     menuContent()
                 }label: {
@@ -76,6 +77,8 @@ public struct VideoPlayerControlView<MenuContent: View>: View {
                         SubtitleMenuView()
                             .pickerStyle(.menu)
                             .menuActionDismissBehavior(.disabled)
+                        PlaybackSpeedMenuView()
+                            .pickerStyle(.menu)
                         Divider()
                         menuContent()
                     } label: {

--- a/Sources/PDVideoPlayer/Common/VideoPlayerEnvironment.swift
+++ b/Sources/PDVideoPlayer/Common/VideoPlayerEnvironment.swift
@@ -17,6 +17,9 @@ private struct VideoPlayerOnCloseKey: @preconcurrency EnvironmentKey {
 private struct VideoPlayerIsMutedKey: EnvironmentKey {
     static let defaultValue: Binding<Bool>? = nil
 }
+private struct VideoPlayerPlaybackSpeedKey: EnvironmentKey {
+    static let defaultValue: Binding<PlaybackSpeed>? = nil
+}
 private struct VideoPlayerControlsVisibleKey: EnvironmentKey {
     static let defaultValue: Binding<Bool>? = nil
 }
@@ -57,6 +60,10 @@ public extension EnvironmentValues {
     var videoPlayerIsMuted: Binding<Bool>? {
         get { self[VideoPlayerIsMutedKey.self] }
         set { self[VideoPlayerIsMutedKey.self] = newValue }
+    }
+    var videoPlayerPlaybackSpeed: Binding<PlaybackSpeed>? {
+        get { self[VideoPlayerPlaybackSpeedKey.self] }
+        set { self[VideoPlayerPlaybackSpeedKey.self] = newValue }
     }
     var videoPlayerOnLongPress: VideoPlayerLongpressAction? {
         get { self[VideoPlayerOnLongPressKey.self] }

--- a/Sources/PDVideoPlayer/iOS/PDVideoPlayer_iOS.swift
+++ b/Sources/PDVideoPlayer/iOS/PDVideoPlayer_iOS.swift
@@ -16,6 +16,7 @@ public struct PDVideoPlayer<MenuContent: View, Content: View>: View {
     private var player: AVPlayer?
 
     var isMuted: Binding<Bool>?
+    var playbackSpeed: Binding<PlaybackSpeed>?
     var foregroundColor: Color = .white
     var onClose: VideoPlayerCloseAction?
     var onLongPress: VideoPlayerLongpressAction?
@@ -61,12 +62,18 @@ public struct PDVideoPlayer<MenuContent: View, Content: View>: View {
                 .videoPlayerKeyboardShortcuts(model)
                 .environment(model)
                 .environment(\.videoPlayerIsMuted, isMuted)
+                .environment(\.videoPlayerPlaybackSpeed, playbackSpeed)
                 .environment(\.videoPlayerOnClose, onClose)
                 .environment(\.videoPlayerOnLongPress, onLongPress)
                 .environment(\.videoPlayerForegroundColor, foregroundColor)
                 .onChange(of: isMuted?.wrappedValue){
                     if let isMuted{
                         model.player.isMuted = isMuted.wrappedValue
+                    }
+                }
+                .onChange(of: playbackSpeed?.wrappedValue){
+                    if let speed = playbackSpeed?.wrappedValue {
+                        model.playbackSpeed = speed
                     }
                 }
                 .onChange(of:foregroundColor){
@@ -103,10 +110,16 @@ public struct PDVideoPlayer<MenuContent: View, Content: View>: View {
                     if let url {
                         let newModel = PDPlayerModel(url: url)
                         newModel.onClose = onClose
+                        if let speed = playbackSpeed?.wrappedValue {
+                            newModel.playbackSpeed = speed
+                        }
                         model = newModel
                     } else if let player {
                         let newModel = PDPlayerModel(player: player)
                         newModel.onClose = onClose
+                        if let speed = playbackSpeed?.wrappedValue {
+                            newModel.playbackSpeed = speed
+                        }
                         model = newModel
                     }
                 }

--- a/Sources/PDVideoPlayer/macOS/PDVideoPlayer_macOS.swift
+++ b/Sources/PDVideoPlayer/macOS/PDVideoPlayer_macOS.swift
@@ -17,6 +17,7 @@ public struct PDVideoPlayer<PlayerMenu: View,
     private var player: AVPlayer?
     
     var isMuted: Binding<Bool>?
+    var playbackSpeed: Binding<PlaybackSpeed>?
     var onClose: VideoPlayerCloseAction?
     var onLongPress: VideoPlayerLongpressAction?
     var foregroundColor: Color = .white
@@ -70,12 +71,18 @@ public struct PDVideoPlayer<PlayerMenu: View,
                 .videoPlayerKeyboardShortcuts(model)
                 .environment(model)
                 .environment(\.videoPlayerIsMuted, isMuted)
+                .environment(\.videoPlayerPlaybackSpeed, playbackSpeed)
                 .environment(\.videoPlayerOnClose, onClose)
                 .environment(\.videoPlayerOnLongPress, onLongPress)
                 .environment(\.videoPlayerForegroundColor, foregroundColor)
                 .onChange(of: isMuted?.wrappedValue){
                     if let isMuted{
                         model.player.isMuted = isMuted.wrappedValue
+                    }
+                }
+                .onChange(of: playbackSpeed?.wrappedValue){
+                    if let speed = playbackSpeed?.wrappedValue {
+                        model.playbackSpeed = speed
                     }
                 }
                 .onChange(of:foregroundColor){
@@ -98,11 +105,17 @@ public struct PDVideoPlayer<PlayerMenu: View,
                         let m = PDPlayerModel(url: url)
                         m.onClose = onClose
                         m.windowDraggable = windowDraggable
+                        if let speed = playbackSpeed?.wrappedValue {
+                            m.playbackSpeed = speed
+                        }
                         model = m
                     } else if let player {
                         let m = PDPlayerModel(player: player)
                         m.onClose = onClose
                         m.windowDraggable = windowDraggable
+                        if let speed = playbackSpeed?.wrappedValue {
+                            m.playbackSpeed = speed
+                        }
                         model = m
                     }
                 }


### PR DESCRIPTION
## Summary
- implement `PlaybackSpeed` enum and `PlaybackSpeedMenuView`
- expose playback speed through environment values and builder extension
- allow `PDVideoPlayer` to set playback speed on model
- support playback speed selection in `VideoPlayerControlView`
- update sample view with new modifier

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*