### PR TITLE
Add adaptive container for player resizing

### DIFF
--- a/Sources/PDVideoPlayer/Common/Player/Extensions/PlayerContainerView.swift
+++ b/Sources/PDVideoPlayer/Common/Player/Extensions/PlayerContainerView.swift
@@ -1,0 +1,29 @@
+#if os(iOS)
+import UIKit
+public final class PlayerContainerView: UIView {
+    weak var playerView: UIView?
+    var contentSize: CGSize?
+    override public func layoutSubviews() {
+        super.layoutSubviews()
+        updateAspectConstraint()
+    }
+    func updateAspectConstraint() {
+        guard let playerView, let contentSize else { return }
+        playerView.setConstraintScalledToFit(in: self, size: contentSize)
+    }
+}
+#elseif os(macOS)
+import AppKit
+public final class PlayerContainerView: NSView {
+    weak var playerView: NSView?
+    var contentSize: CGSize?
+    override public func layout() {
+        super.layout()
+        updateAspectConstraint()
+    }
+    func updateAspectConstraint() {
+        guard let playerView, let contentSize else { return }
+        playerView.setConstraintScalledToFit(in: self, size: contentSize)
+    }
+}
+#endif

--- a/Sources/PDVideoPlayer/Common/Player/VideoPlayerView_iOS.swift
+++ b/Sources/PDVideoPlayer/Common/Player/VideoPlayerView_iOS.swift
@@ -46,7 +46,8 @@ public struct PDVideoPlayerView_iOS: UIViewRepresentable {
         scrollView.showsHorizontalScrollIndicator = false
         scrollView.contentInsetAdjustmentBehavior = .never
        
-        let containerView = UIView()
+        let containerView = PlayerContainerView()
+        context.coordinator.containerView = containerView
         containerView.backgroundColor = .clear
         containerView.tag = 1
         scrollView.addSubview(containerView)
@@ -115,7 +116,9 @@ public struct PDVideoPlayerView_iOS: UIViewRepresentable {
                     Task { @MainActor in
                         context.coordinator.presentationSizeObservation?.invalidate()
                         context.coordinator.presentationSizeObservation = nil
-                        playerView.view.setConstraintScalledToFit(in:containerView,size:size)
+                        containerView.playerView = playerView.view
+                        containerView.contentSize = size
+                        containerView.updateAspectConstraint()
                         onPresentationSizeChange?(playerView.view, size)
                     }
                 }
@@ -144,6 +147,7 @@ public struct PDVideoPlayerView_iOS: UIViewRepresentable {
     public class Coordinator: NSObject, UIScrollViewDelegate {
         var parent: PDVideoPlayerRepresentable
         weak var playerView:AVPlayerViewController?
+        weak var containerView: PlayerContainerView?
         var presentationSizeObservation: NSKeyValueObservation?
         init(_ parent: PDVideoPlayerRepresentable) {
             self.parent = parent

--- a/Sources/PDVideoPlayer/Common/Player/VideoPlayerView_macOS.swift
+++ b/Sources/PDVideoPlayer/Common/Player/VideoPlayerView_macOS.swift
@@ -48,6 +48,7 @@ public struct PDVideoPlayerView_macOS<MenuContent: View>: NSViewRepresentable {
         var presentationSizeObservation: NSKeyValueObservation?
         var parent: PDVideoPlayerView_macOS
         weak var playerView: PlayerNSView?
+        weak var containerView: PlayerContainerView?
 
         init(_ parent: PDVideoPlayerView_macOS) {
             self.parent = parent
@@ -83,7 +84,8 @@ public struct PDVideoPlayerView_macOS<MenuContent: View>: NSViewRepresentable {
 
         let scrollView = model.scrollView
 
-        let containerView = NSView()
+        let containerView = PlayerContainerView()
+        context.coordinator.containerView = containerView
         containerView.translatesAutoresizingMaskIntoConstraints = false
         containerView.wantsLayer = true
         containerView.layer?.backgroundColor = NSColor.clear.cgColor
@@ -140,7 +142,9 @@ public struct PDVideoPlayerView_macOS<MenuContent: View>: NSViewRepresentable {
                     Task{ @MainActor in
                         context.coordinator.presentationSizeObservation?.invalidate()
                         context.coordinator.presentationSizeObservation = nil
-                        playerView.setConstraintScalledToFit(in:containerView,size:size)
+                        containerView.playerView = playerView
+                        containerView.contentSize = size
+                        containerView.updateAspectConstraint()
                         onPresentationSizeChange?(playerView,size)
                     }
                 }


### PR DESCRIPTION
## Summary
- add `PlayerContainerView` to update aspect constraints when layout changes
- connect the new container in iOS and macOS player views
- update constraints during presentation size observation

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_684e7258acf48325aff993130511d150