### PR TITLE
Add videoPlayerMenu modifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,7 @@ struct ContentView: View {
     @State private var isMuted: Bool = false
     @State private var speed: PlaybackSpeed = .x1_0
     var body: some View {
-        PDVideoPlayer(url: videoURL, menu: {
-            Button("Sample 1") { print("Button 1") }
-            Button("Sample 2") { print("Button 2") }
-        }) { proxy in
+        PDVideoPlayer(url: videoURL) { proxy in
             ZStack {
                 proxy.player
                     .onTap { inside in
@@ -65,6 +62,10 @@ struct ContentView: View {
                         .frame(maxWidth: 500,alignment: .center)
                 }
             }
+        }
+        .videoPlayerMenu {
+            Button("Sample 1") { print("Button 1") }
+            Button("Sample 2") { print("Button 2") }
         }
         .isMuted($isMuted)
         .playbackSpeed($speed)

--- a/Sources/PDVideoPlayer/Common/PDVideoPlayerExtensions.swift
+++ b/Sources/PDVideoPlayer/Common/PDVideoPlayerExtensions.swift
@@ -54,4 +54,23 @@ public extension PDVideoPlayer {
 #endif
 }
 
+public extension PDVideoPlayer where MenuContent == EmptyView {
+    /// Attach menu content after initialization.
+    func videoPlayerMenu<NewMenu: View>(
+        @ViewBuilder _ builder: @escaping () -> NewMenu
+    ) -> PDVideoPlayer<NewMenu, Content> {
+        PDVideoPlayer<NewMenu, Content>(
+            url: self.url,
+            player: self.player,
+            isMuted: self.isMuted,
+            playbackSpeed: self.playbackSpeed,
+            foregroundColor: self.foregroundColor,
+            onClose: self.onClose,
+            onLongPress: self.onLongPress,
+            menu: builder,
+            content: self.content
+        )
+    }
+}
+
 #endif

--- a/Sources/PDVideoPlayer/Common/Player/Extensions/ProxyExtensions.swift
+++ b/Sources/PDVideoPlayer/Common/Player/Extensions/ProxyExtensions.swift
@@ -27,10 +27,10 @@ import SwiftUI
 @MainActor
 public extension PDVideoPlayerProxy {
     func player(
-        scrollViewConfigurator: PDVideoPlayerRepresentable<PlayerMenu>.ScrollViewConfigurator? = nil,
-        playerViewConfigurator: PDVideoPlayerRepresentable<PlayerMenu>.PlayerViewConfigurator? = nil,
+        scrollViewConfigurator: PDVideoPlayerRepresentable<MenuContent>.ScrollViewConfigurator? = nil,
+        playerViewConfigurator: PDVideoPlayerRepresentable<MenuContent>.PlayerViewConfigurator? = nil,
         onTap: VideoPlayerTapAction? = nil
-    ) -> PDVideoPlayerRepresentable<PlayerMenu> {
+    ) -> PDVideoPlayerRepresentable<MenuContent> {
         var view = self.player
         if let scrollViewConfigurator {
             view = view.scrollViewConfigurator(scrollViewConfigurator)

--- a/Sources/PDVideoPlayer/Example/PDVideoPlayerSampleView.swift
+++ b/Sources/PDVideoPlayer/Example/PDVideoPlayerSampleView.swift
@@ -14,14 +14,6 @@ struct ContentView: View {
     var body: some View {
         PDVideoPlayer(
             url: sampleURL,
-            menu: {
-                Button("Sample 1") {
-                    print("Button Tapped 1")
-                }
-                Button("Sample 2") {
-                    print("Button Tapped 2")
-                }
-            },
             content: { proxy in
                 ZStack {
                     proxy.player
@@ -60,6 +52,14 @@ struct ContentView: View {
                 }
             }
         )
+        .videoPlayerMenu {
+            Button("Sample 1") {
+                print("Button Tapped 1")
+            }
+            Button("Sample 2") {
+                print("Button Tapped 2")
+            }
+        }
         .isMuted($isMuted)
         .playbackSpeed($speed)
         .onLongPress { value in

--- a/Sources/PDVideoPlayer/iOS/PDVideoPlayer_iOS.swift
+++ b/Sources/PDVideoPlayer/iOS/PDVideoPlayer_iOS.swift
@@ -12,8 +12,8 @@ public struct PDVideoPlayer<MenuContent: View, Content: View>: View {
 
     @State private var model: PDPlayerModel? = nil
 
-    private var url: URL?
-    private var player: AVPlayer?
+    var url: URL?
+    var player: AVPlayer?
 
     var isMuted: Binding<Bool>?
     var playbackSpeed: Binding<PlaybackSpeed>?
@@ -21,29 +21,27 @@ public struct PDVideoPlayer<MenuContent: View, Content: View>: View {
     var onClose: VideoPlayerCloseAction?
     var onLongPress: VideoPlayerLongpressAction?
 
-    private let content: (PDVideoPlayerProxy<MenuContent>) -> Content
-    private let menuContent: () -> MenuContent
-    
-    /// Creates a player from a URL.
-    public init(
-        url: URL,
+    var content: (PDVideoPlayerProxy<MenuContent>) -> Content
+    var menuContent: () -> MenuContent
+
+    init(
+        url: URL?,
+        player: AVPlayer?,
+        isMuted: Binding<Bool>? = nil,
+        playbackSpeed: Binding<PlaybackSpeed>? = nil,
+        foregroundColor: Color = .white,
+        onClose: VideoPlayerCloseAction? = nil,
+        onLongPress: VideoPlayerLongpressAction? = nil,
         @ViewBuilder menu: @escaping () -> MenuContent,
         @ViewBuilder content: @escaping (PDVideoPlayerProxy<MenuContent>) -> Content
-    ){
+    ) {
         self.url = url
-        self.player = nil
-        self.menuContent = menu
-        self.content = content
-    }
-    
-    /// Creates a player from an existing AVPlayer instance.
-    public init(
-        player: AVPlayer,
-        @ViewBuilder menu: @escaping () -> MenuContent,
-        @ViewBuilder content: @escaping (PDVideoPlayerProxy<MenuContent>) -> Content
-    ){
         self.player = player
-        self.url = nil
+        self.isMuted = isMuted
+        self.playbackSpeed = playbackSpeed
+        self.foregroundColor = foregroundColor
+        self.onClose = onClose
+        self.onLongPress = onLongPress
         self.menuContent = menu
         self.content = content
     }
@@ -115,7 +113,12 @@ public extension PDVideoPlayer where MenuContent == EmptyView {
         url: URL,
         @ViewBuilder content: @escaping (PDVideoPlayerProxy<MenuContent>) -> Content
     ) {
-        self.init(url: url, menu: { EmptyView() }, content: content)
+        self.init(
+            url: url,
+            player: nil,
+            menu: { EmptyView() },
+            content: content
+        )
     }
 
     /// Convenience initializer when no menu content is provided.
@@ -123,7 +126,12 @@ public extension PDVideoPlayer where MenuContent == EmptyView {
         player: AVPlayer,
         @ViewBuilder content: @escaping (PDVideoPlayerProxy<MenuContent>) -> Content
     ) {
-        self.init(player: player, menu: { EmptyView() }, content: content)
+        self.init(
+            url: nil,
+            player: player,
+            menu: { EmptyView() },
+            content: content
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- add `.videoPlayerMenu` modifier to supply menu views after initialization
- refactor `PDVideoPlayer` on iOS/macOS to use the modifier and remove menu parameters from initializers
- unify macOS menu types
- update example and README for new API

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_685650ce048883259f5c05814e7b3cc1