### PR TITLE
Add video player menu modifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,7 @@ struct ContentView: View {
     @State private var isMuted: Bool = false
     @State private var speed: PlaybackSpeed = .x1_0
     var body: some View {
-        PDVideoPlayer(url: videoURL, menu: {
-            Button("Sample 1") { print("Button 1") }
-            Button("Sample 2") { print("Button 2") }
-        }) { proxy in
+        PDVideoPlayer(url: videoURL) { proxy in
             ZStack {
                 proxy.player
                     .onTap { inside in
@@ -65,6 +62,10 @@ struct ContentView: View {
                         .frame(maxWidth: 500,alignment: .center)
                 }
             }
+        }
+        .videoPlayerMenu {
+            Button("Sample 1") { print("Button 1") }
+            Button("Sample 2") { print("Button 2") }
         }
         .isMuted($isMuted)
         .playbackSpeed($speed)

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ struct ContentView: View {
         .onClose { value in
             print("onClose", value)
         }
-        .playerForegroundColor(.white)
+        .playerForegroundColor(Color.white)
     }
 }
 ```

--- a/Sources/PDVideoPlayer/Common/Player/Extensions/ProxyExtensions.swift
+++ b/Sources/PDVideoPlayer/Common/Player/Extensions/ProxyExtensions.swift
@@ -27,10 +27,10 @@ import SwiftUI
 @MainActor
 public extension PDVideoPlayerProxy {
     func player(
-        scrollViewConfigurator: PDVideoPlayerRepresentable<PlayerMenu>.ScrollViewConfigurator? = nil,
-        playerViewConfigurator: PDVideoPlayerRepresentable<PlayerMenu>.PlayerViewConfigurator? = nil,
+        scrollViewConfigurator: PDVideoPlayerRepresentable<MenuContent>.ScrollViewConfigurator? = nil,
+        playerViewConfigurator: PDVideoPlayerRepresentable<MenuContent>.PlayerViewConfigurator? = nil,
         onTap: VideoPlayerTapAction? = nil
-    ) -> PDVideoPlayerRepresentable<PlayerMenu> {
+    ) -> PDVideoPlayerRepresentable<MenuContent> {
         var view = self.player
         if let scrollViewConfigurator {
             view = view.scrollViewConfigurator(scrollViewConfigurator)

--- a/Sources/PDVideoPlayer/Example/PDVideoPlayerSampleView.swift
+++ b/Sources/PDVideoPlayer/Example/PDVideoPlayerSampleView.swift
@@ -44,9 +44,9 @@ struct ContentView: View {
                             .frame(maxWidth: 500,alignment: .center)
                     }
                 }
-                .frame(maxWidth: .infinity)
-                .padding(.bottom)
-                
+        .playerForegroundColor(Color.white)
+        .animation(.smooth(duration: 0.12), value: controlsVisible)
+        .background(Color.black)
             }
         }
         .videoPlayerMenu {

--- a/Sources/PDVideoPlayer/Example/PDVideoPlayerSampleView.swift
+++ b/Sources/PDVideoPlayer/Example/PDVideoPlayerSampleView.swift
@@ -12,44 +12,41 @@ struct ContentView: View {
     @State private var speed: PlaybackSpeed = .x1_0
     
     var body: some View {
-        PDVideoPlayer(
-            url: sampleURL
-        ) { proxy in
+        PDVideoPlayer(url: sampleURL) { proxy in
             ZStack {
                 proxy.player
                     .onTap { inside in
                         print("onTap", inside)
                     }
-                        .onPresentationSizeChange({ view, size in
-                            
-                        })
+                    .onPresentationSizeChange({ view, size in
+                        
+                    })
 #if os(iOS)
-                        .contextMenuProvider{ _ in
-                            return uimenu
-                        }
-                        .scrollViewConfigurator { scrollView in
-                            
-                        }
-                        .skipRippleEffect()
-#endif
-                        .ignoresSafeArea()
-                    VStack(alignment:.center) {
-                        if controlsVisible{
-                            proxy.navigation
-                            Spacer()
-                            proxy.control
-#if os(macOS)
-                                .trackpadSwipeOverlay()
-                                .buttonStyle(.plain)
-                                .padding(.horizontal)
-#endif
-                                .frame(maxWidth: 500,alignment: .center)
-                        }
+                    .contextMenuProvider{ _ in
+                        return uimenu
                     }
-                    .frame(maxWidth: .infinity)
-                    .padding(.bottom)
-                    
+                    .scrollViewConfigurator { scrollView in
+                        
+                    }
+                    .skipRippleEffect()
+#endif
+                    .ignoresSafeArea()
+                VStack(alignment:.center) {
+                    if controlsVisible{
+                        proxy.navigation
+                        Spacer()
+                        proxy.control
+#if os(macOS)
+                            .trackpadSwipeOverlay()
+                            .buttonStyle(.plain)
+                            .padding(.horizontal)
+#endif
+                            .frame(maxWidth: 500,alignment: .center)
+                    }
                 }
+                .frame(maxWidth: .infinity)
+                .padding(.bottom)
+                
             }
         }
         .videoPlayerMenu {

--- a/Sources/PDVideoPlayer/Example/PDVideoPlayerSampleView.swift
+++ b/Sources/PDVideoPlayer/Example/PDVideoPlayerSampleView.swift
@@ -13,21 +13,13 @@ struct ContentView: View {
     
     var body: some View {
         PDVideoPlayer(
-            url: sampleURL,
-            menu: {
-                Button("Sample 1") {
-                    print("Button Tapped 1")
-                }
-                Button("Sample 2") {
-                    print("Button Tapped 2")
-                }
-            },
-            content: { proxy in
-                ZStack {
-                    proxy.player
-                        .onTap { inside in
-                            print("onTap", inside)
-                        }
+            url: sampleURL
+        ) { proxy in
+            ZStack {
+                proxy.player
+                    .onTap { inside in
+                        print("onTap", inside)
+                    }
                         .onPresentationSizeChange({ view, size in
                             
                         })
@@ -59,7 +51,15 @@ struct ContentView: View {
                     
                 }
             }
-        )
+        }
+        .videoPlayerMenu {
+            Button("Sample 1") {
+                print("Button Tapped 1")
+            }
+            Button("Sample 2") {
+                print("Button Tapped 2")
+            }
+        }
         .isMuted($isMuted)
         .playbackSpeed($speed)
         .onLongPress { value in

--- a/Sources/PDVideoPlayer/iOS/PDVideoPlayer_iOS.swift
+++ b/Sources/PDVideoPlayer/iOS/PDVideoPlayer_iOS.swift
@@ -122,7 +122,7 @@ public struct PDVideoPlayer<MenuContent: View, Content: View>: View {
 }
 
 public extension PDVideoPlayer where MenuContent == EmptyView {
-    public init(
+    init(
         url: URL,
         @ViewBuilder content: @escaping (PDVideoPlayerProxy<MenuContent>) -> Content
     ) {
@@ -139,7 +139,7 @@ public extension PDVideoPlayer where MenuContent == EmptyView {
         )
     }
 
-    public init(
+    init(
         player: AVPlayer,
         @ViewBuilder content: @escaping (PDVideoPlayerProxy<MenuContent>) -> Content
     ) {
@@ -160,7 +160,7 @@ public extension PDVideoPlayer where MenuContent == EmptyView {
     /// PDVideoPlayer(url: …) { proxy in … }
     ///     .videoPlayerMenu { Button("…") { … } }
     /// ```
-    public func videoPlayerMenu<NewMenu: View>(
+    func videoPlayerMenu<NewMenu: View>(
         @ViewBuilder _ builder: @escaping () -> NewMenu
     ) -> PDVideoPlayer<NewMenu, Content> {
 

--- a/Sources/PDVideoPlayer/iOS/PDVideoPlayer_iOS.swift
+++ b/Sources/PDVideoPlayer/iOS/PDVideoPlayer_iOS.swift
@@ -139,39 +139,7 @@ public extension PDVideoPlayer where MenuContent == EmptyView {
         )
     }
 
-        // 既存 content クロージャを新しいメニュー型にラップ
-        let forwardedContent: (PDVideoPlayerProxy<NewMenu>) -> Content = { proxy in
-            let oldProxy = PDVideoPlayerProxy<MenuContent>(
-                player: proxy.player,
-                control: VideoPlayerControlView<MenuContent>(
-                    model: proxy.control.model,
-                    menuContent: self.menuContent
-                ),
-                navigation: proxy.navigation
-            )
-            return self.content(oldProxy)
-        }
-            player:          player,
-            isMuted:         nil,
-            playbackSpeed:   nil,
-            foregroundColor: .white,
-            onClose:         nil,
-            onLongPress:     nil,
-            menu:            { EmptyView() },
-            content:         content
-        )
-    }
-
-    /// ```
-    /// PDVideoPlayer(url: …) { proxy in … }
-    ///     .videoPlayerMenu { Button("…") { … } }
-    /// ```
-    func videoPlayerMenu<NewMenu: View>(
-        @ViewBuilder _ builder: @escaping () -> NewMenu
-    ) -> PDVideoPlayer<NewMenu, Content> {
-
-        // ◆ content クロージャはメニュー型が違っても実質同一動作。
-        //   unsafeBitCast を使い “型だけ” 書き換えて再利用します。
+    // .videoPlayerMenu は共通拡張へ移動
         let forwardedContent = unsafeBitCast(
             self.content,
             to: ((PDVideoPlayerProxy<NewMenu>) -> Content).self

--- a/Sources/PDVideoPlayer/iOS/PDVideoPlayer_iOS.swift
+++ b/Sources/PDVideoPlayer/iOS/PDVideoPlayer_iOS.swift
@@ -139,12 +139,18 @@ public extension PDVideoPlayer where MenuContent == EmptyView {
         )
     }
 
-    init(
-        player: AVPlayer,
-        @ViewBuilder content: @escaping (PDVideoPlayerProxy<MenuContent>) -> Content
-    ) {
-        self.init(
-            url:             nil,
+        // 既存 content クロージャを新しいメニュー型にラップ
+        let forwardedContent: (PDVideoPlayerProxy<NewMenu>) -> Content = { proxy in
+            let oldProxy = PDVideoPlayerProxy<MenuContent>(
+                player: proxy.player,
+                control: VideoPlayerControlView<MenuContent>(
+                    model: proxy.control.model,
+                    menuContent: self.menuContent
+                ),
+                navigation: proxy.navigation
+            )
+            return self.content(oldProxy)
+        }
             player:          player,
             isMuted:         nil,
             playbackSpeed:   nil,

--- a/Sources/PDVideoPlayer/iOS/PDVideoPlayer_iOS.swift
+++ b/Sources/PDVideoPlayer/iOS/PDVideoPlayer_iOS.swift
@@ -15,14 +15,14 @@ public struct PDVideoPlayer<MenuContent: View, Content: View>: View {
 
     // ② 設定パラメータ (コピーして保持)
     //    ⇒ `internal` にして videoPlayerMenu から読めるように
-    let url: URL?
-    let player: AVPlayer?
+    var url: URL?
+    var player: AVPlayer?
 
-    let isMuted: Binding<Bool>?
-    let playbackSpeed: Binding<PlaybackSpeed>?
-    let foregroundColor: Color
-    let onClose: VideoPlayerCloseAction?
-    let onLongPress: VideoPlayerLongpressAction?
+    var isMuted: Binding<Bool>?
+    var playbackSpeed: Binding<PlaybackSpeed>?
+    var foregroundColor: Color
+    var onClose: VideoPlayerCloseAction?
+    var onLongPress: VideoPlayerLongpressAction?
 
     // ③ 描画クロージャ
     let content: (PDVideoPlayerProxy<MenuContent>) -> Content

--- a/Sources/PDVideoPlayer/macOS/PDVideoPlayer_macOS.swift
+++ b/Sources/PDVideoPlayer/macOS/PDVideoPlayer_macOS.swift
@@ -52,11 +52,25 @@ public extension PDVideoPlayer where MenuContent == EmptyView {
     public func videoPlayerMenu<NewMenu: View>(
         @ViewBuilder _ builder: @escaping () -> NewMenu
     ) -> PDVideoPlayer<NewMenu, Content> {
-
-        let forwardedContent = unsafeBitCast(
-            self.content,
-            to: ((PDVideoPlayerProxy<NewMenu>) -> Content).self
-        )
+        let forwardedContent: (PDVideoPlayerProxy<NewMenu>) -> Content = { proxy in
+            let oldPlayer = PDVideoPlayerRepresentable<MenuContent>(
+                model: proxy.player.model,
+                scrollViewConfigurator: proxy.player.scrollViewConfigurator,
+                playerViewConfigurator: proxy.player.playerViewConfigurator,
+                onPresentationSizeChange: proxy.player.onPresentationSizeChange,
+                onTap: proxy.player.onTap,
+                menuContent: self.menuContent
+            )
+            let oldProxy = PDVideoPlayerProxy<MenuContent>(
+                player: oldPlayer,
+                control: VideoPlayerControlView<MenuContent>(
+                    model: proxy.control.model,
+                    menuContent: self.menuContent
+                ),
+                navigation: proxy.navigation
+            )
+            return self.content(oldProxy)
+        }
 
         return PDVideoPlayer<NewMenu, Content>(
             url:             self.url,

--- a/Sources/PDVideoPlayer/macOS/PDVideoPlayer_macOS.swift
+++ b/Sources/PDVideoPlayer/macOS/PDVideoPlayer_macOS.swift
@@ -45,46 +45,7 @@ public extension PDVideoPlayer where MenuContent == EmptyView {
         )
     }
 
-    /// ````
-    /// PDVideoPlayer(url: …) { proxy in … }
-    ///     .videoPlayerMenu { Button("…") { … } }
-    /// ````
-    public func videoPlayerMenu<NewMenu: View>(
-        @ViewBuilder _ builder: @escaping () -> NewMenu
-    ) -> PDVideoPlayer<NewMenu, Content> {
-        let forwardedContent: (PDVideoPlayerProxy<NewMenu>) -> Content = { proxy in
-            let oldPlayer = PDVideoPlayerRepresentable<MenuContent>(
-                model: proxy.player.model,
-                scrollViewConfigurator: proxy.player.scrollViewConfigurator,
-                playerViewConfigurator: proxy.player.playerViewConfigurator,
-                onPresentationSizeChange: proxy.player.onPresentationSizeChange,
-                onTap: proxy.player.onTap,
-                menuContent: self.menuContent
-            )
-            let oldProxy = PDVideoPlayerProxy<MenuContent>(
-                player: oldPlayer,
-                control: VideoPlayerControlView<MenuContent>(
-                    model: proxy.control.model,
-                    menuContent: self.menuContent
-                ),
-                navigation: proxy.navigation
-            )
-            return self.content(oldProxy)
-        }
-
-        return PDVideoPlayer<NewMenu, Content>(
-            url:             self.url,
-            player:          self.player,
-            isMuted:         self.isMuted,
-            playbackSpeed:   self.playbackSpeed,
-            foregroundColor: self.foregroundColor,
-            onClose:         self.onClose,
-            onLongPress:     self.onLongPress,
-            windowDraggable: self.windowDraggable,
-            menu:            builder,
-            content:         forwardedContent
-        )
-    }
+    // .videoPlayerMenu は共通拡張へ移動
 }
 
 public struct PDVideoPlayer<MenuContent: View, Content: View>: View {

--- a/Sources/PDVideoPlayer/macOS/PDVideoPlayer_macOS.swift
+++ b/Sources/PDVideoPlayer/macOS/PDVideoPlayer_macOS.swift
@@ -83,16 +83,16 @@ public struct PDVideoPlayer<MenuContent: View, Content: View>: View {
     // ② 設定パラメータ (コピーして保持)
     //    ⇒ `internal` にして videoPlayerMenu から読めるように
     // ------------------------------------------------------------------ //
-    let url: URL?
-    let player: AVPlayer?
+    var url: URL?
+    var player: AVPlayer?
 
-    let isMuted: Binding<Bool>?
-    let playbackSpeed: Binding<PlaybackSpeed>?
-    let onClose: VideoPlayerCloseAction?
-    let onLongPress: VideoPlayerLongpressAction?
-    let foregroundColor: Color
+    var isMuted: Binding<Bool>?
+    var playbackSpeed: Binding<PlaybackSpeed>?
+    var onClose: VideoPlayerCloseAction?
+    var onLongPress: VideoPlayerLongpressAction?
+    var foregroundColor: Color
     /// Enables moving the window when dragging on the player view.
-    let windowDraggable: Bool
+    var windowDraggable: Bool
 
     // ------------------------------------------------------------------ //
     // ③ 描画クロージャ


### PR DESCRIPTION
## Summary
- remove menu parameters from `PDVideoPlayer` initializers
- add `.videoPlayerMenu` modifier for supplying menus
- support the modifier on both iOS and macOS
- update sample and README usage for new API

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_685652c59abc8325bada9f41f5c6c54c