### PR TITLE
Implement videoPlayerMenu modifier

### DIFF
--- a/Sources/PDVideoPlayer/Common/Player/Extensions/ProxyExtensions.swift
+++ b/Sources/PDVideoPlayer/Common/Player/Extensions/ProxyExtensions.swift
@@ -27,10 +27,10 @@ import SwiftUI
 @MainActor
 public extension PDVideoPlayerProxy {
     func player(
-        scrollViewConfigurator: PDVideoPlayerRepresentable<PlayerMenu>.ScrollViewConfigurator? = nil,
-        playerViewConfigurator: PDVideoPlayerRepresentable<PlayerMenu>.PlayerViewConfigurator? = nil,
+        scrollViewConfigurator: PDVideoPlayerRepresentable<MenuContent>.ScrollViewConfigurator? = nil,
+        playerViewConfigurator: PDVideoPlayerRepresentable<MenuContent>.PlayerViewConfigurator? = nil,
         onTap: VideoPlayerTapAction? = nil
-    ) -> PDVideoPlayerRepresentable<PlayerMenu> {
+    ) -> PDVideoPlayerRepresentable<MenuContent> {
         var view = self.player
         if let scrollViewConfigurator {
             view = view.scrollViewConfigurator(scrollViewConfigurator)

--- a/Sources/PDVideoPlayer/Example/PDVideoPlayerSampleView.swift
+++ b/Sources/PDVideoPlayer/Example/PDVideoPlayerSampleView.swift
@@ -14,14 +14,6 @@ struct ContentView: View {
     var body: some View {
         PDVideoPlayer(
             url: sampleURL,
-            menu: {
-                Button("Sample 1") {
-                    print("Button Tapped 1")
-                }
-                Button("Sample 2") {
-                    print("Button Tapped 2")
-                }
-            },
             content: { proxy in
                 ZStack {
                     proxy.player
@@ -60,6 +52,14 @@ struct ContentView: View {
                 }
             }
         )
+        .videoPlayerMenu {
+            Button("Sample 1") {
+                print("Button Tapped 1")
+            }
+            Button("Sample 2") {
+                print("Button Tapped 2")
+            }
+        }
         .isMuted($isMuted)
         .playbackSpeed($speed)
         .onLongPress { value in


### PR DESCRIPTION
## Summary
- support setting menus via `videoPlayerMenu` modifier
- adjust macOS implementation to share the same modifier
- update example usage

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68565bb213a48325abe0186e9ead1303