### PR TITLE
Implement menu modifier for PDVideoPlayer

### DIFF
--- a/Sources/PDVideoPlayer/Common/PDVideoPlayerMenuModifier.swift
+++ b/Sources/PDVideoPlayer/Common/PDVideoPlayerMenuModifier.swift
@@ -1,0 +1,36 @@
+#if os(iOS) || os(macOS)
+import SwiftUI
+
+extension PDVideoPlayer {
+    // Internal initializer used by the modifier
+    init<NewMenu: View>(
+        base: Self,
+        menu: @escaping () -> NewMenu
+    ) where MenuContent == EmptyView {
+        self.url = base.url
+        self.player = base.player
+        self.isMuted = base.isMuted
+        self.playbackSpeed = base.playbackSpeed
+        self.foregroundColor = base.foregroundColor
+        self.onClose = base.onClose
+        self.onLongPress = base.onLongPress
+#if os(macOS)
+        self.windowDraggable = base.windowDraggable
+#endif
+        self.menuContent = menu
+        self.content = { proxy in
+            // call original content by dropping menu information
+            base.content(proxy.withoutMenu())
+        }
+    }
+}
+
+public extension PDVideoPlayer where MenuContent == EmptyView {
+    /// Provides menu content for the player via modifier.
+    func menu<NewMenu: View>(
+        @ViewBuilder _ builder: @escaping () -> NewMenu
+    ) -> PDVideoPlayer<NewMenu, Content> {
+        PDVideoPlayer<NewMenu, Content>(base: self, menu: builder)
+    }
+}
+#endif

--- a/Sources/PDVideoPlayer/Common/PDVideoPlayerMenuModifier.swift
+++ b/Sources/PDVideoPlayer/Common/PDVideoPlayerMenuModifier.swift
@@ -20,9 +20,10 @@ extension PDVideoPlayer {
         self.windowDraggable = base.windowDraggable
 #endif
         self.menuContent = menu
+        let baseContent: (PDVideoPlayerProxy<MenuContent>) -> Content =
+            unsafeBitCast(base.content, to: ((PDVideoPlayerProxy<MenuContent>) -> Content).self)
         self.content = { proxy in
-            // call original content by dropping menu information
-            base.content(proxy.withoutMenu())
+            baseContent(proxy)
         }
     }
 }

--- a/Sources/PDVideoPlayer/Common/PDVideoPlayerMenuModifier.swift
+++ b/Sources/PDVideoPlayer/Common/PDVideoPlayerMenuModifier.swift
@@ -2,11 +2,11 @@
 import SwiftUI
 
 extension PDVideoPlayer {
-    // Internal initializer used by the modifier
-    init<NewMenu: View>(
-        base: Self,
-        menu: @escaping () -> NewMenu
-    ) where MenuContent == EmptyView {
+    // Internal initializer used by the menu modifier
+    init<OldMenu: View>(
+        base: PDVideoPlayer<OldMenu, Content>,
+        menu: @escaping () -> MenuContent
+    ) where OldMenu == EmptyView {
         self.url = base.url
         self.player = base.player
         self.isMuted = base.isMuted

--- a/Sources/PDVideoPlayer/Common/PDVideoPlayerMenuModifier.swift
+++ b/Sources/PDVideoPlayer/Common/PDVideoPlayerMenuModifier.swift
@@ -2,11 +2,13 @@
 import SwiftUI
 
 extension PDVideoPlayer {
-    // Internal initializer used by the menu modifier
-    init<OldMenu: View>(
-        base: PDVideoPlayer<OldMenu, Content>,
+    // Internal initializer used by the menu modifier. Only available when the
+    // original player had no menu content.
+    @MainActor
+    init(
+        base: PDVideoPlayer<EmptyView, Content>,
         menu: @escaping () -> MenuContent
-    ) where OldMenu == EmptyView {
+    ) {
         self.url = base.url
         self.player = base.player
         self.isMuted = base.isMuted

--- a/Sources/PDVideoPlayer/Common/Player/Extensions/ProxyExtensions.swift
+++ b/Sources/PDVideoPlayer/Common/Player/Extensions/ProxyExtensions.swift
@@ -27,10 +27,10 @@ import SwiftUI
 @MainActor
 public extension PDVideoPlayerProxy {
     func player(
-        scrollViewConfigurator: PDVideoPlayerRepresentable<PlayerMenu>.ScrollViewConfigurator? = nil,
-        playerViewConfigurator: PDVideoPlayerRepresentable<PlayerMenu>.PlayerViewConfigurator? = nil,
+        scrollViewConfigurator: PDVideoPlayerRepresentable<MenuContent>.ScrollViewConfigurator? = nil,
+        playerViewConfigurator: PDVideoPlayerRepresentable<MenuContent>.PlayerViewConfigurator? = nil,
         onTap: VideoPlayerTapAction? = nil
-    ) -> PDVideoPlayerRepresentable<PlayerMenu> {
+    ) -> PDVideoPlayerRepresentable<MenuContent> {
         var view = self.player
         if let scrollViewConfigurator {
             view = view.scrollViewConfigurator(scrollViewConfigurator)
@@ -45,3 +45,21 @@ public extension PDVideoPlayerProxy {
     }
 }
 #endif
+
+public extension PDVideoPlayerProxy {
+    func withoutMenu() -> PDVideoPlayerProxy<EmptyView> {
+#if os(iOS)
+        PDVideoPlayerProxy<EmptyView>(
+            player: self.player,
+            control: self.control.withoutMenu(),
+            navigation: self.navigation
+        )
+#else
+        PDVideoPlayerProxy<EmptyView>(
+            player: self.player.withoutMenu(),
+            control: self.control.withoutMenu(),
+            navigation: self.navigation
+        )
+#endif
+    }
+}

--- a/Sources/PDVideoPlayer/Common/Player/Extensions/ProxyExtensions.swift
+++ b/Sources/PDVideoPlayer/Common/Player/Extensions/ProxyExtensions.swift
@@ -46,6 +46,7 @@ public extension PDVideoPlayerProxy {
 }
 #endif
 
+@MainActor
 public extension PDVideoPlayerProxy {
     func withoutMenu() -> PDVideoPlayerProxy<EmptyView> {
 #if os(iOS)

--- a/Sources/PDVideoPlayer/Common/Player/Extensions/RepresentableMac.swift
+++ b/Sources/PDVideoPlayer/Common/Player/Extensions/RepresentableMac.swift
@@ -28,5 +28,15 @@ public extension PDVideoPlayerRepresentable {
              onTap: self.onTap,
              menuContent: self.menuContent)
     }
+    func withoutMenu() -> PDVideoPlayerRepresentable<EmptyView> {
+        PDVideoPlayerRepresentable<EmptyView>(
+            model: self.model,
+            scrollViewConfigurator: self.scrollViewConfigurator,
+            playerViewConfigurator: self.playerViewConfigurator,
+            onPresentationSizeChange: self.onPresentationSizeChange,
+            onTap: self.onTap,
+            menuContent: { EmptyView() }
+        )
+    }
 }
 #endif

--- a/Sources/PDVideoPlayer/Common/Player/Extensions/RepresentableMac.swift
+++ b/Sources/PDVideoPlayer/Common/Player/Extensions/RepresentableMac.swift
@@ -1,6 +1,7 @@
 #if os(macOS)
 import SwiftUI
 
+@MainActor
 public extension PDVideoPlayerRepresentable {
     func scrollViewConfigurator(_ configurator: @escaping ScrollViewConfigurator) -> Self {
         Self(model: self.model,

--- a/Sources/PDVideoPlayer/Common/VideoPlayerControlView.swift
+++ b/Sources/PDVideoPlayer/Common/VideoPlayerControlView.swift
@@ -207,6 +207,7 @@ extension EnvironmentValues {
     }
 }
 
+@MainActor
 public extension VideoPlayerControlView {
     func withoutMenu() -> VideoPlayerControlView<EmptyView> {
         VideoPlayerControlView<EmptyView>(model: self.model, menuContent: { EmptyView() })

--- a/Sources/PDVideoPlayer/Common/VideoPlayerControlView.swift
+++ b/Sources/PDVideoPlayer/Common/VideoPlayerControlView.swift
@@ -206,3 +206,9 @@ extension EnvironmentValues {
         set { self[IsPressedKey.self] = newValue }
     }
 }
+
+public extension VideoPlayerControlView {
+    func withoutMenu() -> VideoPlayerControlView<EmptyView> {
+        VideoPlayerControlView<EmptyView>(model: self.model, menuContent: { EmptyView() })
+    }
+}

--- a/Sources/PDVideoPlayer/iOS/PDVideoPlayer_iOS.swift
+++ b/Sources/PDVideoPlayer/iOS/PDVideoPlayer_iOS.swift
@@ -12,8 +12,8 @@ public struct PDVideoPlayer<MenuContent: View, Content: View>: View {
 
     @State private var model: PDPlayerModel? = nil
 
-    private var url: URL?
-    private var player: AVPlayer?
+    var url: URL?
+    var player: AVPlayer?
 
     var isMuted: Binding<Bool>?
     var playbackSpeed: Binding<PlaybackSpeed>?
@@ -21,8 +21,8 @@ public struct PDVideoPlayer<MenuContent: View, Content: View>: View {
     var onClose: VideoPlayerCloseAction?
     var onLongPress: VideoPlayerLongpressAction?
 
-    private let content: (PDVideoPlayerProxy<MenuContent>) -> Content
-    private let menuContent: () -> MenuContent
+    let content: (PDVideoPlayerProxy<MenuContent>) -> Content
+    var menuContent: () -> MenuContent
     
     /// Creates a player from a URL.
     @available(*, deprecated, message: "Use menu() modifier")

--- a/Sources/PDVideoPlayer/iOS/PDVideoPlayer_iOS.swift
+++ b/Sources/PDVideoPlayer/iOS/PDVideoPlayer_iOS.swift
@@ -25,6 +25,7 @@ public struct PDVideoPlayer<MenuContent: View, Content: View>: View {
     private let menuContent: () -> MenuContent
     
     /// Creates a player from a URL.
+    @available(*, deprecated, message: "Use menu() modifier")
     public init(
         url: URL,
         @ViewBuilder menu: @escaping () -> MenuContent,
@@ -37,6 +38,7 @@ public struct PDVideoPlayer<MenuContent: View, Content: View>: View {
     }
     
     /// Creates a player from an existing AVPlayer instance.
+    @available(*, deprecated, message: "Use menu() modifier")
     public init(
         player: AVPlayer,
         @ViewBuilder menu: @escaping () -> MenuContent,

--- a/Sources/PDVideoPlayer/macOS/PDVideoPlayer_macOS.swift
+++ b/Sources/PDVideoPlayer/macOS/PDVideoPlayer_macOS.swift
@@ -11,8 +11,8 @@ public struct PDVideoPlayerProxy<MenuContent: View> {
 public struct PDVideoPlayer<MenuContent: View, Content: View>: View {
     @State private var model: PDPlayerModel? = nil
     
-    private var url: URL?
-    private var player: AVPlayer?
+    var url: URL?
+    var player: AVPlayer?
     
     var isMuted: Binding<Bool>?
     var playbackSpeed: Binding<PlaybackSpeed>?
@@ -22,8 +22,8 @@ public struct PDVideoPlayer<MenuContent: View, Content: View>: View {
     /// Enables moving the window when dragging on the player view.
     var windowDraggable: Bool = false
     
-    private let menuContent: () -> MenuContent
-    private let content: (PDVideoPlayerProxy<MenuContent>) -> Content
+    var menuContent: () -> MenuContent
+    let content: (PDVideoPlayerProxy<MenuContent>) -> Content
     
     @available(*, deprecated, message: "Use menu() modifier")
     public init(

--- a/Sources/PDVideoPlayer/macOS/PDVideoPlayer_macOS.swift
+++ b/Sources/PDVideoPlayer/macOS/PDVideoPlayer_macOS.swift
@@ -2,15 +2,13 @@
 import SwiftUI
 import AVKit
 
-public struct PDVideoPlayerProxy<PlayerMenu: View, ControlMenu: View> {
-    public let player: PDVideoPlayerRepresentable<PlayerMenu>
-    public let control: VideoPlayerControlView<ControlMenu>
+public struct PDVideoPlayerProxy<MenuContent: View> {
+    public let player: PDVideoPlayerRepresentable<MenuContent>
+    public let control: VideoPlayerControlView<MenuContent>
     public let navigation: VideoPlayerNavigationView
 }
 
-public struct PDVideoPlayer<PlayerMenu: View,
-                            ControlMenu: View,
-                            Content: View>: View {
+public struct PDVideoPlayer<MenuContent: View, Content: View>: View {
     @State private var model: PDPlayerModel? = nil
     
     private var url: URL?
@@ -24,31 +22,28 @@ public struct PDVideoPlayer<PlayerMenu: View,
     /// Enables moving the window when dragging on the player view.
     var windowDraggable: Bool = false
     
-    private let playerMenu: () -> PlayerMenu
-    private let controlMenu: () -> ControlMenu
-    private let content: (PDVideoPlayerProxy<PlayerMenu, ControlMenu>) -> Content
+    private let menuContent: () -> MenuContent
+    private let content: (PDVideoPlayerProxy<MenuContent>) -> Content
     
+    @available(*, deprecated, message: "Use menu() modifier")
     public init(
         url: URL,
-        @ViewBuilder playerMenu: @escaping () -> PlayerMenu,
-        @ViewBuilder controlMenu: @escaping () -> ControlMenu,
-        @ViewBuilder content: @escaping (PDVideoPlayerProxy<PlayerMenu, ControlMenu>) -> Content
+        @ViewBuilder menu: @escaping () -> MenuContent,
+        @ViewBuilder content: @escaping (PDVideoPlayerProxy<MenuContent>) -> Content
     ) {
         self.url = url
-        self.playerMenu = playerMenu
-        self.controlMenu = controlMenu
+        self.menuContent = menu
         self.content = content
     }
-    
+
+    @available(*, deprecated, message: "Use menu() modifier")
     public init(
         player: AVPlayer,
-        @ViewBuilder playerMenu: @escaping () -> PlayerMenu,
-        @ViewBuilder controlMenu: @escaping () -> ControlMenu,
-        @ViewBuilder content: @escaping (PDVideoPlayerProxy<PlayerMenu, ControlMenu>) -> Content
+        @ViewBuilder menu: @escaping () -> MenuContent,
+        @ViewBuilder content: @escaping (PDVideoPlayerProxy<MenuContent>) -> Content
     ) {
         self.player = player
-        self.playerMenu = playerMenu
-        self.controlMenu = controlMenu
+        self.menuContent = menu
         self.content = content
     }
     
@@ -58,11 +53,11 @@ public struct PDVideoPlayer<PlayerMenu: View,
                 player: PDVideoPlayerRepresentable(
                     model: model,
                     playerViewConfigurator: { _ in },
-                    menuContent: playerMenu
+                    menuContent: menuContent
                 ),
                 control: VideoPlayerControlView(
                     model: model,
-                    menuContent: controlMenu
+                    menuContent: menuContent
                 ),
                 navigation: VideoPlayerNavigationView()
             )
@@ -120,32 +115,6 @@ public struct PDVideoPlayer<PlayerMenu: View,
     }
 }
 
-extension PDVideoPlayer where PlayerMenu == ControlMenu {
-    public init(
-        url: URL,
-        @ViewBuilder menu: @escaping () -> PlayerMenu,
-        @ViewBuilder content: @escaping (PDVideoPlayerProxy<PlayerMenu, PlayerMenu>) -> Content
-    ) {
-        self.init(
-            url: url,
-            playerMenu: menu,
-            controlMenu: menu,
-            content: content
-        )
-    }
-    
-    public init(
-        player: AVPlayer,
-        @ViewBuilder menu: @escaping () -> PlayerMenu,
-        @ViewBuilder content: @escaping (PDVideoPlayerProxy<PlayerMenu, PlayerMenu>) -> Content
-    ) {
-        self.init(
-            player: player,
-            playerMenu: menu,
-            controlMenu: menu,
-            content: content
-        )
-    }
-}
+
 
 #endif


### PR DESCRIPTION
## Summary
- add internal initializer and menu modifier
- support removing menu via `withoutMenu` helpers
- unify macOS player to use a single menu
- deprecate menu parameters in initializers

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_685676bdb9bc83259af0390a5cfdae0f