### PR TITLE
Move long-press change handler

### DIFF
--- a/Sources/PDVideoPlayer/Common/VideoPlayerNavigationView.swift
+++ b/Sources/PDVideoPlayer/Common/VideoPlayerNavigationView.swift
@@ -74,9 +74,6 @@ public struct VideoPlayerNavigationView:View{
             }
         }
         .animation(.smooth(duration:0.12),value:model.isLongpress)
-        .onChange(of: model.isLongpress) {
-            onLongPress?(model.isLongpress)
-        }
         
     }
     private var fastView: some View {

--- a/Sources/PDVideoPlayer/PDVideoPlayer.swift
+++ b/Sources/PDVideoPlayer/PDVideoPlayer.swift
@@ -102,6 +102,9 @@ public struct PDVideoPlayer<MenuContent: View, Content: View>: View {
                 .onChange(of: player) {
                     if let player { model.replacePlayer(with: player) }
                 }
+                .onChange(of: model.isLongpress) { value in
+                    onLongPress?(value)
+                }
         } else {
             Color.clear
                 .task {


### PR DESCRIPTION
## Summary
- move `.onChange` for `isLongpress` from `VideoPlayerNavigationView` to `PDVideoPlayer`

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_685a6e7fdb588325836da71dfa596a50