### PR TITLE
Extract navigation overlays

### DIFF
--- a/Sources/PDVideoPlayer/Common/FastForwardIndicatorView.swift
+++ b/Sources/PDVideoPlayer/Common/FastForwardIndicatorView.swift
@@ -1,0 +1,31 @@
+#if os(iOS) || os(macOS)
+import SwiftUI
+
+/// Overlay indicating the temporary fast-forward playback speed.
+public struct FastForwardIndicatorView: View {
+    @Environment(PDPlayerModel.self) private var model
+    @Environment(\.videoPlayerForegroundColor) private var foregroundColor
+
+    public init() {}
+
+    public var body: some View {
+        HStack(spacing: 4) {
+            Text("\(min(2.0, model.originalRate * 2.0), specifier: \"%.1f\")x")
+            Image(systemName: "forward.fill")
+                .imageScale(.small)
+        }
+        .fontDesign(.rounded)
+        .fontWeight(.semibold)
+        .font(.callout)
+        .foregroundStyle(foregroundColor)
+        .opacity(0.8)
+        .padding(.vertical, 4)
+        .padding(.horizontal, 12)
+        .background {
+            RoundedRectangle(cornerRadius: 12)
+                .fill(.ultraThinMaterial)
+                .environment(\.colorScheme, .dark)
+        }
+    }
+}
+#endif

--- a/Sources/PDVideoPlayer/Common/VideoPlayerNavigationView.swift
+++ b/Sources/PDVideoPlayer/Common/VideoPlayerNavigationView.swift
@@ -68,48 +68,13 @@ public struct VideoPlayerNavigationView:View{
             .frame(height:44)
             .padding(.horizontal,12)
            
-            if model.isLongpress{
-                fastView
+            if model.isLongpress {
+                FastForwardIndicatorView()
                     .transition(.opacity)
             }
         }
         .animation(.smooth(duration:0.12),value:model.isLongpress)
         
-    }
-    private var fastView: some View {
-        HStack(spacing:4){
-            Text("\(min(2.0, model.originalRate * 2.0), specifier: "%.1f")x")
-            Image(systemName:"forward.fill")
-                .imageScale(.small)
-        }
-        .fontDesign(.rounded)
-        .fontWeight(.semibold)
-        .font(.callout)
-        .foregroundStyle(foregroundColor)
-        .opacity(0.8)
-        .padding(.vertical,4)
-        .padding(.horizontal,12)
-        .background{
-            RoundedRectangle(cornerRadius: 12)
-                .fill(.ultraThinMaterial)
-                .environment(\.colorScheme, .dark)
-            
-        }
-    }
-    private var pipButton: some View{
-        Button{
-            PiPManager.shared.start()
-        }label:{
-            ZStack{
-                Color.clear
-                Image(systemName:"pip.enter")
-                    .foregroundStyle(foregroundColor)
-                    .fontDesign(.rounded)
-                    .opacity(0.8)
-            }
-            .contentShape(Rectangle())
-            
-        }
     }
 }
 #endif

--- a/Sources/PDVideoPlayer/iOS/PictureInPictureButton.swift
+++ b/Sources/PDVideoPlayer/iOS/PictureInPictureButton.swift
@@ -1,0 +1,25 @@
+#if canImport(UIKit) && !os(visionOS)
+import SwiftUI
+
+/// Button to start Picture-in-Picture playback.
+public struct PictureInPictureButton: View {
+    @Environment(\.videoPlayerForegroundColor) private var foregroundColor
+
+    public init() {}
+
+    public var body: some View {
+        Button {
+            PiPManager.shared.start()
+        } label: {
+            ZStack {
+                Color.clear
+                Image(systemName: "pip.enter")
+                    .foregroundStyle(foregroundColor)
+                    .fontDesign(.rounded)
+                    .opacity(0.8)
+            }
+            .contentShape(Rectangle())
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- factor out FastForwardIndicatorView and PictureInPictureButton as public views
- use FastForwardIndicatorView in VideoPlayerNavigationView

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_685a6fd007648325af72b4b49ab137f1