### PR TITLE
Use Entry macro for environment values

### DIFF
--- a/Sources/PDVideoPlayer/Common/VideoPlayerControlView.swift
+++ b/Sources/PDVideoPlayer/Common/VideoPlayerControlView.swift
@@ -196,13 +196,8 @@ struct PlayButtonStyle: ButtonStyle {
             .environment(\.isPressed, configuration.isPressed)
     }
 }
-private struct IsPressedKey: EnvironmentKey {
-    static let defaultValue: Bool = false
-}
 
 extension EnvironmentValues {
-    var isPressed: Bool {
-        get { self[IsPressedKey.self] }
-        set { self[IsPressedKey.self] = newValue }
-    }
+    /// Define `isPressed` using the `@Entry` macro available in Xcode 16.
+    @Entry var isPressed: Bool = false
 }

--- a/Sources/PDVideoPlayer/Common/VideoPlayerEnvironment.swift
+++ b/Sources/PDVideoPlayer/Common/VideoPlayerEnvironment.swift
@@ -11,15 +11,8 @@ public struct VideoPlayerCloseAction {
     }
 }
 
-private struct VideoPlayerOnCloseKey: @preconcurrency EnvironmentKey {
-    @MainActor static let defaultValue: VideoPlayerCloseAction? = nil
-}
-private struct VideoPlayerPlaybackSpeedKey: @preconcurrency EnvironmentKey {
-    @MainActor static let defaultValue: Binding<PlaybackSpeed>? = nil
-}
-private struct VideoPlayerControlsVisibleKey: EnvironmentKey {
-    static let defaultValue: Binding<Bool>? = nil
-}
+/// Environment entries defined with the new `@Entry` macro available in Xcode 16.
+/// This replaces the old `EnvironmentKey` structs.
 
 public struct VideoPlayerLongpressAction {
     let action: (Bool) -> Void
@@ -41,44 +34,17 @@ public struct VideoPlayerTapAction {
     }
 }
 
-private struct VideoPlayerOnLongPressKey: @preconcurrency EnvironmentKey {
-    @MainActor static let defaultValue: VideoPlayerLongpressAction? = nil
-}
-
-private struct VideoPlayerForegroundColorKey: EnvironmentKey {
-    static let defaultValue: Color = .white
-}
-
+extension EnvironmentValues {
+    /// Xcode 16 の `@Entry` マクロを利用した環境値の定義
+    @Entry var videoPlayerOnClose: VideoPlayerCloseAction? = nil
+    @Entry var videoPlayerPlaybackSpeed: Binding<PlaybackSpeed>? = nil
+    @Entry var videoPlayerControlsVisible: Binding<Bool>? = nil
+    @Entry var videoPlayerOnLongPress: VideoPlayerLongpressAction? = nil
+    @Entry var videoPlayerForegroundColor: Color = .white
 #if os(macOS)
-private struct VideoPlayerSliderKnobSizeKey: EnvironmentKey {
-    static let defaultValue: CGFloat = 12
-}
+    @Entry var videoPlayerSliderKnobSize: CGFloat = 12
 #else
-private struct VideoPlayerSliderKnobSizeKey: EnvironmentKey {
-    static let defaultValue: CGFloat = 6
-}
+    @Entry var videoPlayerSliderKnobSize: CGFloat = 6
 #endif
-
-public extension EnvironmentValues {
-    var videoPlayerOnClose: VideoPlayerCloseAction? {
-        get { self[VideoPlayerOnCloseKey.self] }
-        set { self[VideoPlayerOnCloseKey.self] = newValue }
-    }
-    var videoPlayerPlaybackSpeed: Binding<PlaybackSpeed>? {
-        get { self[VideoPlayerPlaybackSpeedKey.self] }
-        set { self[VideoPlayerPlaybackSpeedKey.self] = newValue }
-    }
-    var videoPlayerOnLongPress: VideoPlayerLongpressAction? {
-        get { self[VideoPlayerOnLongPressKey.self] }
-        set { self[VideoPlayerOnLongPressKey.self] = newValue }
-    }
-    var videoPlayerForegroundColor: Color {
-        get { self[VideoPlayerForegroundColorKey.self] }
-        set { self[VideoPlayerForegroundColorKey.self] = newValue }
-    }
-    var videoPlayerSliderKnobSize: CGFloat {
-        get { self[VideoPlayerSliderKnobSizeKey.self] }
-        set { self[VideoPlayerSliderKnobSizeKey.self] = newValue }
-    }
 }
 


### PR DESCRIPTION
## Summary
- adopt the new `@Entry` macro from Xcode 16 for custom environment values
- simplify `isPressed` environment value definition

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_685b8d661b4c83258a49ce67057a9584