### PR TITLE
Disable scroll during fast-forward

### DIFF
--- a/Sources/PDVideoPlayer/Common/Player/VideoPlayerView_iOS.swift
+++ b/Sources/PDVideoPlayer/Common/Player/VideoPlayerView_iOS.swift
@@ -210,10 +210,7 @@ public struct PDVideoPlayerView_iOS: UIViewRepresentable {
                     self.parent.model.player.rate = min(self.parent.model.originalRate * 2.0, 2.0)
                     self.parent.model.isLongpress = true
                     // Disable scrolling and zooming while fast forwarding
-                    let scrollView = self.parent.model.scrollView
-                    scrollView.isScrollEnabled = false
-                    scrollView.panGestureRecognizer.isEnabled = false
-                    scrollView.pinchGestureRecognizer?.isEnabled = false
+                    self.parent.model.scrollView.panGestureRecognizer.isEnabled = false
                     self.parent.onLongPress?(true)
                 }
             case .ended, .cancelled, .failed:
@@ -221,10 +218,7 @@ public struct PDVideoPlayerView_iOS: UIViewRepresentable {
                 self.parent.model.player.rate = self.parent.model.originalRate
                 self.parent.model.isLongpress = false
                 // Re-enable scroll and pinch gestures
-                let scrollView = self.parent.model.scrollView
-                scrollView.isScrollEnabled = true
-                scrollView.panGestureRecognizer.isEnabled = true
-                scrollView.pinchGestureRecognizer?.isEnabled = true
+                self.parent.model.scrollView.panGestureRecognizer.isEnabled = true
                 self.parent.onLongPress?(false)
             default:
                 break

--- a/Sources/PDVideoPlayer/Common/Player/VideoPlayerView_iOS.swift
+++ b/Sources/PDVideoPlayer/Common/Player/VideoPlayerView_iOS.swift
@@ -209,12 +209,22 @@ public struct PDVideoPlayerView_iOS: UIViewRepresentable {
                     // 現在のレートの2倍にする
                     self.parent.model.player.rate = min(self.parent.model.originalRate * 2.0, 2.0)
                     self.parent.model.isLongpress = true
+                    // Disable scrolling and zooming while fast forwarding
+                    let scrollView = self.parent.model.scrollView
+                    scrollView.isScrollEnabled = false
+                    scrollView.panGestureRecognizer.isEnabled = false
+                    scrollView.pinchGestureRecognizer?.isEnabled = false
                     self.parent.onLongPress?(true)
                 }
             case .ended, .cancelled, .failed:
                 // 長押し終了時に元のレートに戻す
                 self.parent.model.player.rate = self.parent.model.originalRate
                 self.parent.model.isLongpress = false
+                // Re-enable scroll and pinch gestures
+                let scrollView = self.parent.model.scrollView
+                scrollView.isScrollEnabled = true
+                scrollView.panGestureRecognizer.isEnabled = true
+                scrollView.pinchGestureRecognizer?.isEnabled = true
                 self.parent.onLongPress?(false)
             default:
                 break


### PR DESCRIPTION
## Summary
- stop UIScrollView pan/pinch while long-press fast-forwarding

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_687b427dbbf08325833224917b732c64