### PR TITLE
Add preview wrapper for PDPlayerModel

### DIFF
--- a/Sources/PDVideoPlayer/Common/FastForwardIndicatorView.swift
+++ b/Sources/PDVideoPlayer/Common/FastForwardIndicatorView.swift
@@ -38,4 +38,19 @@ public struct FastForwardIndicatorView: View {
         }
     }
 }
+
+#if DEBUG
+#Preview {
+    PDPlayerModelPreview { model in
+        Rectangle()
+            .fill(.indigo)
+            .ignoresSafeArea()
+            .overlay(alignment: .top) {
+                FastForwardIndicatorView()
+            }
+            .task { model.isLongpress = true }
+    }
+}
+#endif
+
 #endif

--- a/Sources/PDVideoPlayer/Example/PDPlayerModelPreview.swift
+++ b/Sources/PDVideoPlayer/Example/PDPlayerModelPreview.swift
@@ -1,0 +1,21 @@
+#if DEBUG
+import SwiftUI
+import AVKit
+
+/// A helper view for SwiftUI previews that provides a `PDPlayerModel` environment.
+public struct PDPlayerModelPreview<Content: View>: View {
+    @State private var model: PDPlayerModel
+    private let content: (PDPlayerModel) -> Content
+
+    public init(player: AVPlayer = AVPlayer(),
+                @ViewBuilder content: @escaping (PDPlayerModel) -> Content) {
+        _model = State(initialValue: PDPlayerModel(player: player))
+        self.content = content
+    }
+
+    public var body: some View {
+        content(model)
+            .environment(model)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- introduce `PDPlayerModelPreview` for use in SwiftUI previews
- add preview example for `FastForwardIndicatorView` using the wrapper

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_687b497ae8fc8325a92b630888a7e20b