### PR TITLE
Update slider height condition

### DIFF
--- a/Sources/PDVideoPlayer/Common/Slider/VideoPlayerSlider.swift
+++ b/Sources/PDVideoPlayer/Common/Slider/VideoPlayerSlider.swift
@@ -203,8 +203,17 @@ class VideoPlayerSlider: UISlider {
         super.cancelTracking(with: event)
     }
     override var intrinsicContentSize: CGSize {
+#if swift(>=6.2)
+        if #available(iOS 26.0, macOS 26.0, *) {
+            return super.intrinsicContentSize
+        } else {
+            let size = super.intrinsicContentSize
+            return CGSize(width: size.width, height: size.height + 40)
+        }
+#else
         let size = super.intrinsicContentSize
         return CGSize(width: size.width, height: size.height + 40)
+#endif
     }
 
 }


### PR DESCRIPTION
## Summary
- keep default slider height on new OS versions

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_687b520ceb8c8325b7a7c5c774d47d71