### PR TITLE
Extract menu into separate view

### DIFF
--- a/Sources/PDVideoPlayer/Common/VideoPlayerControlView.swift
+++ b/Sources/PDVideoPlayer/Common/VideoPlayerControlView.swift
@@ -73,32 +73,8 @@ public struct VideoPlayerControlView<MenuContent: View>: View {
                         .padding(.trailing,48)
                         .padding(.bottom,1.5)
                     
-                    Menu {
-                        SubtitleMenuView()
-                            .pickerStyle(.menu)
-                            .menuActionDismissBehavior(.disabled)
-                        PlaybackSpeedMenuView()
-                            .pickerStyle(.menu)
-                            .menuActionDismissBehavior(.disabled)
-                        Divider()
+                    VideoPlayerMenuView {
                         menuContent()
-                    } label: {
-                        ZStack(alignment: .bottomTrailing) {
-                            Rectangle()
-                                .foregroundStyle(.clear)
-                                .contentShape(Rectangle())
-                            Image(systemName: "ellipsis.circle")
-                                .font(.callout)
-                                .foregroundStyle(foregroundColor)
-                                .opacity(0.8)
-                                .padding(.top, 12)
-                            
-                        }
-                        
-                        .frame(width: 60, height: 60)
-                        .padding(.trailing)
-                        .padding(.leading,4)
-                        .contentShape(Rectangle())
                     }
                 }
                 .frame(height:60)

--- a/Sources/PDVideoPlayer/Common/VideoPlayerMenuView.swift
+++ b/Sources/PDVideoPlayer/Common/VideoPlayerMenuView.swift
@@ -1,0 +1,41 @@
+#if os(iOS)
+import SwiftUI
+
+/// A menu containing subtitle and playback speed controls.
+public struct VideoPlayerMenuView<MenuContent: View>: View {
+    private let menuContent: () -> MenuContent
+    @Environment(\.videoPlayerForegroundColor) private var foregroundColor
+
+    public init(@ViewBuilder menuContent: @escaping () -> MenuContent) {
+        self.menuContent = menuContent
+    }
+
+    public var body: some View {
+        Menu {
+            SubtitleMenuView()
+                .pickerStyle(.menu)
+                .menuActionDismissBehavior(.disabled)
+            PlaybackSpeedMenuView()
+                .pickerStyle(.menu)
+                .menuActionDismissBehavior(.disabled)
+            Divider()
+            menuContent()
+        } label: {
+            ZStack(alignment: .bottomTrailing) {
+                Rectangle()
+                    .foregroundStyle(.clear)
+                    .contentShape(Rectangle())
+                Image(systemName: "ellipsis.circle")
+                    .font(.callout)
+                    .foregroundStyle(foregroundColor)
+                    .opacity(0.8)
+                    .padding(.top, 12)
+            }
+            .frame(width: 60, height: 60)
+            .padding(.trailing)
+            .padding(.leading, 4)
+            .contentShape(Rectangle())
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- factor out control menu into `VideoPlayerMenuView`
- reuse new menu view inside `VideoPlayerControlView` for iOS

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_687b553b380c8325bd79a24224e45cf4