### PR TITLE
Add dynamic elapsed and remaining time

### DIFF
--- a/Sources/PDVideoPlayer/Common/Control/ModernVideoPlayerControlView.swift
+++ b/Sources/PDVideoPlayer/Common/Control/ModernVideoPlayerControlView.swift
@@ -106,14 +106,14 @@ struct ModernVideoPlayerControlView<MenuContent: View>: View {
             }
       
             HStack{
-                Text("0:03")
+                Text(model.currentTime.mmSSString)
                     .monospaced()
                     .font(.caption)
                     .fontDesign(.rounded)
                     .foregroundStyle(foregroundColor)
                     .opacity(0.8)
                 VideoPlayerSliderView(viewModel: model)
-                Text("-0:16")
+                Text("-\(max(model.duration - model.currentTime, 0).mmSSString)")
                     .monospaced()
                     .font(.caption)
                     .fontDesign(.rounded)

--- a/Sources/PDVideoPlayer/Common/Utilities/TimeFormatting.swift
+++ b/Sources/PDVideoPlayer/Common/Utilities/TimeFormatting.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension Double {
+    var mmSSString: String {
+        guard self.isFinite && self >= 0 else { return "00:00" }
+        let totalSec = Int(self)
+        let minutes = totalSec / 60
+        let seconds = totalSec % 60
+        return String(format: "%02d:%02d", minutes, seconds)
+    }
+}


### PR DESCRIPTION
## Summary
- compute formatted time strings via `mmSSString` helper
- show current and remaining time in `ModernVideoPlayerControlView`

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_687b750e4b388325995bb45a97d8f227