### PR TITLE
Fix playback resume after seek

### DIFF
--- a/Sources/PDVideoPlayer/Common/Player/PDPlayerModel.swift
+++ b/Sources/PDVideoPlayer/Common/Player/PDPlayerModel.swift
@@ -233,13 +233,25 @@ public class PDPlayerModel: NSObject, DynamicProperty {
 
     public func seek(to seconds: Double) {
         let time = CMTime(seconds: seconds, preferredTimescale: CMTimeScale(NSEC_PER_SEC))
-        player.seek(to: time)
+        let shouldResume = isPlaying
+        player.seek(to: time) { [weak self] _ in
+            guard let self else { return }
+            if shouldResume {
+                self.player.rate = self.playbackSpeed.value
+            }
+        }
     }
 
     public func seekPrecisely(to seconds: Double) {
         let cm = CMTime(seconds: seconds, preferredTimescale: CMTimeScale(NSEC_PER_SEC))
-        player.seek(to: cm, toleranceBefore: .zero, toleranceAfter: .zero)
-        currentTime = seconds
+        let shouldResume = isPlaying
+        player.seek(to: cm, toleranceBefore: .zero, toleranceAfter: .zero) { [weak self] _ in
+            guard let self else { return }
+            if shouldResume {
+                self.player.rate = self.playbackSpeed.value
+            }
+            self.currentTime = seconds
+        }
     }
 
     // MARK: - Keyboard Navigation Support

--- a/Sources/PDVideoPlayer/Common/Player/PDPlayerModel.swift
+++ b/Sources/PDVideoPlayer/Common/Player/PDPlayerModel.swift
@@ -232,22 +232,23 @@ public class PDPlayerModel: NSObject, DynamicProperty {
     }
 
     public func seek(to seconds: Double) {
-        let time = CMTime(seconds: seconds, preferredTimescale: CMTimeScale(NSEC_PER_SEC))
-        let shouldResume = isPlaying
-        player.seek(to: time) { [weak self] _ in
-            guard let self else { return }
-            if shouldResume {
-                self.player.rate = self.playbackSpeed.value
+        Task{
+            let time = CMTime(seconds: seconds, preferredTimescale: CMTimeScale(NSEC_PER_SEC))
+            let shouldResume = isPlaying
+            if await player.seek(to: time){
+                if shouldResume {
+                    self.player.rate = self.playbackSpeed.value
+                }
             }
         }
     }
 
     public func seekPrecisely(to seconds: Double) {
-        let cm = CMTime(seconds: seconds, preferredTimescale: CMTimeScale(NSEC_PER_SEC))
-        let shouldResume = isPlaying
-        player.seek(to: cm, toleranceBefore: .zero, toleranceAfter: .zero) { [weak self] _ in
-            guard let self else { return }
-            if shouldResume {
+        Task{
+            let cm = CMTime(seconds: seconds, preferredTimescale: CMTimeScale(NSEC_PER_SEC))
+            let shouldResume = isPlaying
+            let result = await player.seek(to: cm, toleranceBefore: .zero, toleranceAfter: .zero)
+            if result, shouldResume{
                 self.player.rate = self.playbackSpeed.value
             }
             self.currentTime = seconds


### PR DESCRIPTION
## Summary
- ensure player resumes at previous playback speed after seeking completes

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_687b8263d73c832584d2819f7bf770f3