### PR TITLE
Fix playback state after seeking

### DIFF
--- a/Sources/PDVideoPlayer/Common/Player/PDPlayerModel.swift
+++ b/Sources/PDVideoPlayer/Common/Player/PDPlayerModel.swift
@@ -235,9 +235,10 @@ public class PDPlayerModel: NSObject, DynamicProperty {
         Task{
             let time = CMTime(seconds: seconds, preferredTimescale: CMTimeScale(NSEC_PER_SEC))
             let shouldResume = isPlaying
-            if await player.seek(to: time){
+            if await player.seek(to: time) {
                 if shouldResume {
-                    self.player.rate = self.playbackSpeed.value
+                    player.play()
+                    player.rate = playbackSpeed.value
                 }
             }
         }
@@ -248,8 +249,9 @@ public class PDPlayerModel: NSObject, DynamicProperty {
             let cm = CMTime(seconds: seconds, preferredTimescale: CMTimeScale(NSEC_PER_SEC))
             let shouldResume = isPlaying
             let result = await player.seek(to: cm, toleranceBefore: .zero, toleranceAfter: .zero)
-            if result, shouldResume{
-                self.player.rate = self.playbackSpeed.value
+            if result, shouldResume {
+                player.play()
+                player.rate = playbackSpeed.value
             }
             self.currentTime = seconds
         }


### PR DESCRIPTION
## Summary
- ensure playback state resumes correctly when seeking

## Testing
- `swift test --disable-sandbox` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_687b885a3f308325b57040ce23976b99