### PR TITLE
Fix isPlaying update during seek

### DIFF
--- a/Sources/PDVideoPlayer/Common/Player/PDPlayerModel.swift
+++ b/Sources/PDVideoPlayer/Common/Player/PDPlayerModel.swift
@@ -218,9 +218,17 @@ public class PDPlayerModel: NSObject, DynamicProperty {
         }
         player.play()
         player.rate = playbackSpeed.value
+        if !isPlaying {
+            isPlaying = true
+        }
     }
 
-    func pause() { player.pause() }
+    func pause() {
+        player.pause()
+        if isPlaying {
+            isPlaying = false
+        }
+    }
 
     public func togglePlay() {
         isPlaying ? pause() : play()


### PR DESCRIPTION
## Summary
- directly update `isPlaying` when starting or pausing playback

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_687b885a3f308325b57040ce23976b99