### PR TITLE
Add delay before showing buffering indicator

### DIFF
--- a/Sources/PDVideoPlayer/Common/Control/ModernVideoPlayerControlView.swift
+++ b/Sources/PDVideoPlayer/Common/Control/ModernVideoPlayerControlView.swift
@@ -71,7 +71,7 @@ struct ModernVideoPlayerControlView<MenuContent: View>: View {
                             }
                         }
                         .frame(width: baseSize, height: baseSize)
-                        if model.isBuffering{
+                        if model.showBufferingIndicator{
                             ProgressView()
                                 .frame(width: baseSize, height: baseSize)
                         }
@@ -79,7 +79,7 @@ struct ModernVideoPlayerControlView<MenuContent: View>: View {
                     .glassEffect(.clear)
                     .tint(foregroundColor.opacity(0.8))
                 }
-                .animation(.default,value:model.isBuffering)
+                .animation(.default,value:model.showBufferingIndicator)
                 Spacer()
                 
                 Menu {

--- a/Sources/PDVideoPlayer/Common/Control/VideoPlayerControlViewLegacy.swift
+++ b/Sources/PDVideoPlayer/Common/Control/VideoPlayerControlViewLegacy.swift
@@ -109,7 +109,7 @@ public struct PlayPauseButton: View{
                     .contentShape(Rectangle())
                 HStack(spacing:12){
                     PlayPauseIcon(model: model)
-                    if model.isBuffering{
+                    if model.showBufferingIndicator{
 #if os(macOS)
                     ProgressView()
                         .opacity(0)
@@ -126,7 +126,7 @@ public struct PlayPauseButton: View{
                     }
                     Spacer(minLength: 0)
                 }
-                .animation(.smooth(duration:0.2),value:model.isBuffering)
+                .animation(.smooth(duration:0.2),value:model.showBufferingIndicator)
             }
         }
         .buttonStyle(PlayButtonStyle())

--- a/Sources/PDVideoPlayer/Common/Player/PDPlayerModel.swift
+++ b/Sources/PDVideoPlayer/Common/Player/PDPlayerModel.swift
@@ -23,7 +23,23 @@ public class PDPlayerModel: NSObject, DynamicProperty {
 
     let slider : VideoPlayerSlider
     public var isTracking = false
-    public var isBuffering: Bool = false
+    public var isBuffering: Bool = false {
+        didSet {
+            if isBuffering {
+                bufferingTask?.cancel()
+                bufferingTask = Task { [weak self] in
+                    try? await Task.sleep(for: .milliseconds(300))
+                    guard !Task.isCancelled else { return }
+                    self?.showBufferingIndicator = true
+                }
+            } else {
+                bufferingTask?.cancel()
+                showBufferingIndicator = false
+            }
+        }
+    }
+    public var showBufferingIndicator: Bool = false
+    @ObservationIgnored private var bufferingTask: Task<(), Never>?
 
     public var player: AVPlayer
     public var onClose: VideoPlayerCloseAction?


### PR DESCRIPTION
## Summary
- delay showing `ProgressView` to avoid flickering when buffering

## Testing
- `swift test` *(fails: `swift: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687c937684348325a1157bd914d5c365