### PR TITLE
Fix seeking revert when dragging slider

### DIFF
--- a/Sources/PDVideoPlayer/Common/Player/PDPlayerModel.swift
+++ b/Sources/PDVideoPlayer/Common/Player/PDPlayerModel.swift
@@ -264,8 +264,10 @@ public class PDPlayerModel: NSObject, DynamicProperty {
 
     public func seekPrecisely(to seconds: Double) {
         let cm = CMTime(seconds: seconds, preferredTimescale: CMTimeScale(NSEC_PER_SEC))
-        player.seek(to: cm, toleranceBefore: .zero, toleranceAfter: .zero)
-        currentTime = seconds
+        player.seek(to: cm) { [weak self] _ in
+            guard let self else { return }
+            self.currentTime = CMTimeGetSeconds(self.player.currentTime())
+        }
     }
 
     // MARK: - Keyboard Navigation Support


### PR DESCRIPTION
## Summary
- prevent slider seeks from reverting by handling player seek completion

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68900eecea7483259b6f9086f6931513