### PR TITLE
Add fallback for precise seek to keep slider position

### DIFF
--- a/Sources/PDVideoPlayer/Common/Player/PDPlayerModel.swift
+++ b/Sources/PDVideoPlayer/Common/Player/PDPlayerModel.swift
@@ -264,14 +264,14 @@ public class PDPlayerModel: NSObject, DynamicProperty {
 
     public func seekPrecisely(to seconds: Double) {
         let target = CMTime(seconds: seconds, preferredTimescale: CMTimeScale(NSEC_PER_SEC))
-        player.seek(to: target, toleranceBefore: .zero, toleranceAfter: .zero) { [weak self] _ in
+        player.seek(to: target, toleranceBefore: .zero, toleranceAfter: .zero) { [weak self] result in
             guard let self else { return }
-            let actual = self.player.currentTime()
-            // フォールバック: 厳密なシークに失敗した場合は通常のシークを行う
-            if abs(CMTimeGetSeconds(actual) - seconds) > 0.01 {
-                self.player.seek(to: target)
+            Task{ @MainActor in
+                if !result {
+                    self.player.seek(to: target)
+                }
+                self.currentTime = CMTimeGetSeconds(self.player.currentTime())
             }
-            self.currentTime = CMTimeGetSeconds(self.player.currentTime())
         }
     }
 

--- a/Sources/PDVideoPlayer/Common/Player/PDPlayerModel.swift
+++ b/Sources/PDVideoPlayer/Common/Player/PDPlayerModel.swift
@@ -263,9 +263,16 @@ public class PDPlayerModel: NSObject, DynamicProperty {
     }
 
     public func seekPrecisely(to seconds: Double) {
-        let cm = CMTime(seconds: seconds, preferredTimescale: CMTimeScale(NSEC_PER_SEC))
-        player.seek(to: cm, toleranceBefore: .zero, toleranceAfter: .zero)
-        currentTime = seconds
+        let target = CMTime(seconds: seconds, preferredTimescale: CMTimeScale(NSEC_PER_SEC))
+        player.seek(to: target, toleranceBefore: .zero, toleranceAfter: .zero) { [weak self] _ in
+            guard let self else { return }
+            let actual = self.player.currentTime()
+            // フォールバック: 厳密なシークに失敗した場合は通常のシークを行う
+            if abs(CMTimeGetSeconds(actual) - seconds) > 0.01 {
+                self.player.seek(to: target)
+            }
+            self.currentTime = CMTimeGetSeconds(self.player.currentTime())
+        }
     }
 
     // MARK: - Keyboard Navigation Support


### PR DESCRIPTION
## Summary
- fallback to regular seek if precise seek misses the target
- keep currentTime in sync with player's position after seeking

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68900eecea7483259b6f9086f6931513