### PR TITLE
refactor: player event stream lifecycle

### DIFF
--- a/Sources/PDVideoPlayer/Common/Player/ViewModel/PlayerEngine.swift
+++ b/Sources/PDVideoPlayer/Common/Player/ViewModel/PlayerEngine.swift
@@ -7,9 +7,6 @@ final class PlayerEngine {
         case time(current: Double, duration: Double)
         case status(AVPlayer.TimeControlStatus, AVPlayer.WaitingReason?)
         case itemReady
-    }
-
-    enum StreamError: Error {
         case itemFailed(underlying: Error?)
     }
 
@@ -170,7 +167,7 @@ final class PlayerEngine {
                 case .readyToPlay:
                     yieldEvent(.itemReady, streamID: streamID)
                 case .failed:
-                    finishStream(throwing: StreamError.itemFailed(underlying: item.error), streamID: streamID)
+                    yieldEvent(.itemFailed(underlying: item.error), streamID: streamID)
                     return
                 default:
                     break
@@ -179,14 +176,6 @@ final class PlayerEngine {
         } catch {
             return
         }
-    }
-
-    private func finishStream(throwing error: Error, streamID: UUID) {
-        guard currentStreamID == streamID else { return }
-        cancelObservationTasks()
-        eventContinuation?.finish(throwing: error)
-        eventContinuation = nil
-        currentStreamID = nil
     }
 
     private func currentDurationSeconds() -> Double {

--- a/Sources/PDVideoPlayer/Common/Player/ViewModel/PlayerEngine.swift
+++ b/Sources/PDVideoPlayer/Common/Player/ViewModel/PlayerEngine.swift
@@ -49,7 +49,7 @@ final class PlayerEngine {
         startObservationTasks(streamID: streamID)
 
         return PlayerEventStream(stream: stream) { [weak self] in
-            DispatchQueue.main.async { [weak self] in
+            Task { @MainActor [weak self] in
                 self?.invalidateStreamIfCurrent(streamID: streamID)
             }
         }

--- a/Sources/PDVideoPlayer/Common/Player/ViewModel/PlayerEngine.swift
+++ b/Sources/PDVideoPlayer/Common/Player/ViewModel/PlayerEngine.swift
@@ -1,27 +1,32 @@
 import Foundation
 import AVFoundation
 
+enum PlayerEngineEvent: Sendable {
+    case time(current: Double, duration: Double)
+    case status(AVPlayer.TimeControlStatus, AVPlayer.WaitingReason?)
+    case itemReady
+    case itemFailed(description: String?)
+}
+
 @MainActor
 final class PlayerEngine {
-    enum Event {
-        case time(current: Double, duration: Double)
-        case status(AVPlayer.TimeControlStatus, AVPlayer.WaitingReason?)
-        case itemReady
-        case itemFailed(underlying: Error?)
-    }
-
     private(set) var player: AVPlayer
 
     private var timeTask: Task<Void, Never>?
     private var statusTask: Task<Void, Never>?
     private var currentItemTask: Task<Void, Never>?
-    private var eventContinuation: AsyncStream<Event>.Continuation?
-    private var currentStreamID: UUID?
+    private var eventBroadcaster = EventBroadcaster<PlayerEngineEvent>()
     private let observer: PlayerEngineObserving
 
     init(player: AVPlayer, observer: PlayerEngineObserving = PlayerEngineObserver()) {
         self.player = player
         self.observer = observer
+        eventBroadcaster.onFirstSubscriber = { [weak self] in
+            self?.startObservationTasks()
+        }
+        eventBroadcaster.onLastSubscriber = { [weak self] in
+            self?.cancelObservationTasks()
+        }
     }
 
     func replacePlayer(with newPlayer: AVPlayer) {
@@ -31,38 +36,17 @@ final class PlayerEngine {
     }
 
     func startObserving() -> PlayerEventStream {
-        stopObserving(finishStream: true)
         player.appliesMediaSelectionCriteriaAutomatically = false
 
-        let streamID = UUID()
-        currentStreamID = streamID
-        let stream = AsyncStream<Event> { continuation in
-            eventContinuation = continuation
-        }
-
         let (initialTime, initialDuration) = observer.initialTime(for: player)
-        yieldEvent(.time(current: initialTime.isFinite ? initialTime : 0, duration: initialDuration), streamID: streamID)
-
-        startObservationTasks(streamID: streamID)
-
-        return PlayerEventStream(stream: stream) { [weak self] in
-            Task { @MainActor [weak self] in
-                self?.invalidateStreamIfCurrent(streamID: streamID)
-            }
+        return eventBroadcaster.makeStream { continuation in
+            continuation.yield(.time(current: initialTime.isFinite ? initialTime : 0, duration: initialDuration))
         }
     }
 
     func stopObserving() {
-        stopObserving(finishStream: true)
-    }
-
-    private func stopObserving(finishStream: Bool) {
         cancelObservationTasks()
-        if finishStream {
-            eventContinuation?.finish()
-        }
-        eventContinuation = nil
-        currentStreamID = nil
+        eventBroadcaster.finishAll()
     }
 
     private func cancelObservationTasks() {
@@ -74,14 +58,7 @@ final class PlayerEngine {
         currentItemTask = nil
     }
 
-    private func invalidateStreamIfCurrent(streamID: UUID) {
-        guard currentStreamID == streamID else { return }
-        cancelObservationTasks()
-        eventContinuation = nil
-        currentStreamID = nil
-    }
-
-    private func startObservationTasks(streamID: UUID) {
+    private func startObservationTasks() {
         timeTask?.cancel()
         statusTask?.cancel()
         currentItemTask?.cancel()
@@ -91,45 +68,45 @@ final class PlayerEngine {
         let itemStream = observer.currentItemStream(for: player)
 
         timeTask = Task { @MainActor [weak self] in
-            await self?.observeTime(stream: timeStream, streamID: streamID)
+            await self?.observeTime(stream: timeStream)
         }
 
         statusTask = Task { @MainActor [weak self] in
-            await self?.observeStatus(stream: statusStream, streamID: streamID)
+            await self?.observeStatus(stream: statusStream)
         }
 
         currentItemTask = Task { @MainActor [weak self] in
-            await self?.observeCurrentItem(stream: itemStream, streamID: streamID)
+            await self?.observeCurrentItem(stream: itemStream)
         }
     }
 
-    private func observeTime(stream: AnyAsyncSequence<CMTime>, streamID: UUID) async {
+    private func observeTime(stream: AnyAsyncSequence<CMTime>) async {
         let timeStream = stream
         do {
             for try await time in timeStream {
                 guard !Task.isCancelled else { break }
                 let current = CMTimeGetSeconds(time)
                 let duration = currentDurationSeconds()
-                yieldEvent(.time(current: current.isFinite ? current : 0, duration: duration), streamID: streamID)
+                yieldEvent(.time(current: current.isFinite ? current : 0, duration: duration))
             }
         } catch {
             return
         }
     }
 
-    private func observeStatus(stream: AnyAsyncSequence<AVPlayer.TimeControlStatus>, streamID: UUID) async {
+    private func observeStatus(stream: AnyAsyncSequence<AVPlayer.TimeControlStatus>) async {
         let statusStream = stream
         do {
             for try await status in statusStream {
                 guard !Task.isCancelled else { break }
-                yieldEvent(.status(status, observer.waitingReason(for: player)), streamID: streamID)
+                yieldEvent(.status(status, observer.waitingReason(for: player)))
             }
         } catch {
             return
         }
     }
 
-    private func observeCurrentItem(stream: AnyAsyncSequence<Void>, streamID: UUID) async {
+    private func observeCurrentItem(stream: AnyAsyncSequence<Void>) async {
         let itemStream = stream
         var itemTask: Task<Void, Never>?
         var didReceiveInitialItem = false
@@ -143,14 +120,14 @@ final class PlayerEngine {
 
                 if didReceiveInitialItem {
                     let (initialTime, initialDuration) = observer.initialTime(for: player)
-                    yieldEvent(.time(current: initialTime.isFinite ? initialTime : 0, duration: initialDuration), streamID: streamID)
+                    yieldEvent(.time(current: initialTime.isFinite ? initialTime : 0, duration: initialDuration))
                 } else {
                     didReceiveInitialItem = true
                 }
 
                 guard let item = player.currentItem else { continue }
                 itemTask = Task { @MainActor [weak self] in
-                    await self?.observeItemStatus(for: item, streamID: streamID)
+                    await self?.observeItemStatus(for: item)
                 }
             }
         } catch {
@@ -158,16 +135,16 @@ final class PlayerEngine {
         }
     }
 
-    private func observeItemStatus(for item: AVPlayerItem, streamID: UUID) async {
+    private func observeItemStatus(for item: AVPlayerItem) async {
         let statusStream = observer.itemStatusStream(for: item)
         do {
             for try await status in statusStream {
                 guard !Task.isCancelled else { break }
                 switch status {
                 case .readyToPlay:
-                    yieldEvent(.itemReady, streamID: streamID)
+                    yieldEvent(.itemReady)
                 case .failed:
-                    yieldEvent(.itemFailed(underlying: item.error), streamID: streamID)
+                    yieldEvent(.itemFailed(description: item.error?.localizedDescription))
                 default:
                     break
                 }
@@ -183,9 +160,8 @@ final class PlayerEngine {
         return total.isFinite ? total : 0
     }
 
-    private func yieldEvent(_ event: Event, streamID: UUID) {
-        guard currentStreamID == streamID else { return }
-        eventContinuation?.yield(event)
+    private func yieldEvent(_ event: PlayerEngineEvent) {
+        eventBroadcaster.broadcast(event)
     }
 
     isolated deinit {
@@ -194,56 +170,59 @@ final class PlayerEngine {
 }
 
 @MainActor
-final class PlayerEventStream: AsyncSequence {
-    typealias Element = PlayerEngine.Event
-    typealias AsyncIterator = Iterator
+private final class EventBroadcaster<Event: Sendable> {
+    typealias Stream = AsyncStream<Event>
 
-    nonisolated let stream: AsyncStream<Element>
-    private let onTermination: @Sendable () -> Void
+    private var continuations: [UUID: Stream.Continuation] = [:]
+    var onFirstSubscriber: () -> Void = {}
+    var onLastSubscriber: () -> Void = {}
 
-    init(
-        stream: AsyncStream<Element>,
-        onTermination: @escaping @Sendable () -> Void
-    ) {
-        self.stream = stream
-        self.onTermination = onTermination
-    }
+    func makeStream(onSubscribe: ((Stream.Continuation) -> Void)? = nil) -> Stream {
+        Stream { [weak self] continuation in
+            guard let self else {
+                continuation.finish()
+                return
+            }
 
-    nonisolated func makeAsyncIterator() -> Iterator {
-        Iterator(
-            iterator: stream.makeAsyncIterator(),
-            onTermination: onTermination
-        )
-    }
+            let streamID = UUID()
+            continuations[streamID] = continuation
 
-    isolated deinit {
-        onTermination()
-    }
+            onSubscribe?(continuation)
 
-    final class Iterator: AsyncIteratorProtocol {
-        private var iterator: AsyncStream<PlayerEngine.Event>.Iterator
-        private var onTermination: (@Sendable () -> Void)?
+            if continuations.count == 1 {
+                onFirstSubscriber()
+            }
 
-        init(
-            iterator: AsyncStream<PlayerEngine.Event>.Iterator,
-            onTermination: @escaping @Sendable () -> Void
-        ) {
-            self.iterator = iterator
-            self.onTermination = onTermination
+            continuation.onTermination = { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    self?.removeContinuation(id: streamID)
+                }
+            }
         }
+    }
 
-        func next() async -> PlayerEngine.Event? {
-            var localIterator = iterator
-            defer { iterator = localIterator }
-            return await localIterator.next()
+    func broadcast(_ event: Event) {
+        guard !continuations.isEmpty else { return }
+        for continuation in continuations.values {
+            continuation.yield(event)
         }
+    }
 
-        deinit {
-            onTermination?()
-            onTermination = nil
+    func finishAll() {
+        let activeContinuations = Array(continuations.values)
+        continuations.removeAll()
+        activeContinuations.forEach { $0.finish() }
+    }
+
+    private func removeContinuation(id: UUID) {
+        guard continuations.removeValue(forKey: id) != nil else { return }
+        if continuations.isEmpty {
+            onLastSubscriber()
         }
     }
 }
+
+typealias PlayerEventStream = AsyncStream<PlayerEngineEvent>
 
 struct AnyAsyncSequence<Element>: AsyncSequence {
     typealias AsyncIterator = AnyAsyncIterator<Element>

--- a/Sources/PDVideoPlayer/Common/Player/ViewModel/PlayerEngine.swift
+++ b/Sources/PDVideoPlayer/Common/Player/ViewModel/PlayerEngine.swift
@@ -15,7 +15,7 @@ final class PlayerEngine {
     private var timeTask: Task<Void, Never>?
     private var statusTask: Task<Void, Never>?
     private var currentItemTask: Task<Void, Never>?
-    private var eventContinuation: AsyncThrowingStream<Event, Error>.Continuation?
+    private var eventContinuation: AsyncStream<Event>.Continuation?
     private var currentStreamID: UUID?
     private let observer: PlayerEngineObserving
 
@@ -36,7 +36,7 @@ final class PlayerEngine {
 
         let streamID = UUID()
         currentStreamID = streamID
-        let stream = AsyncThrowingStream<Event, Error> { continuation in
+        let stream = AsyncStream<Event> { continuation in
             eventContinuation = continuation
         }
 
@@ -199,11 +199,11 @@ final class PlayerEventStream: AsyncSequence {
     typealias Element = PlayerEngine.Event
     typealias AsyncIterator = Iterator
 
-    nonisolated let stream: AsyncThrowingStream<Element, Error>
+    nonisolated let stream: AsyncStream<Element>
     private let onTermination: @Sendable () -> Void
 
     init(
-        stream: AsyncThrowingStream<Element, Error>,
+        stream: AsyncStream<Element>,
         onTermination: @escaping @Sendable () -> Void
     ) {
         self.stream = stream
@@ -222,21 +222,21 @@ final class PlayerEventStream: AsyncSequence {
     }
 
     final class Iterator: AsyncIteratorProtocol {
-        private var iterator: AsyncThrowingStream<PlayerEngine.Event, Error>.AsyncIterator
+        private var iterator: AsyncStream<PlayerEngine.Event>.Iterator
         private var onTermination: (@Sendable () -> Void)?
 
         init(
-            iterator: AsyncThrowingStream<PlayerEngine.Event, Error>.AsyncIterator,
+            iterator: AsyncStream<PlayerEngine.Event>.Iterator,
             onTermination: @escaping @Sendable () -> Void
         ) {
             self.iterator = iterator
             self.onTermination = onTermination
         }
 
-        func next() async throws -> PlayerEngine.Event? {
+        func next() async -> PlayerEngine.Event? {
             var localIterator = iterator
             defer { iterator = localIterator }
-            return try await localIterator.next()
+            return await localIterator.next()
         }
 
         deinit {

--- a/Sources/PDVideoPlayer/Common/Player/ViewModel/PlayerEngine.swift
+++ b/Sources/PDVideoPlayer/Common/Player/ViewModel/PlayerEngine.swift
@@ -49,7 +49,9 @@ final class PlayerEngine {
         startObservationTasks(streamID: streamID)
 
         return PlayerEventStream(stream: stream) { [weak self] in
-            self?.invalidateStreamIfCurrent(streamID: streamID)
+            DispatchQueue.main.async { [weak self] in
+                self?.invalidateStreamIfCurrent(streamID: streamID)
+            }
         }
     }
 
@@ -206,25 +208,52 @@ final class PlayerEngine {
 @MainActor
 final class PlayerEventStream: AsyncSequence {
     typealias Element = PlayerEngine.Event
-    typealias AsyncIterator = AsyncThrowingStream<Element, Error>.AsyncIterator
+    typealias AsyncIterator = Iterator
 
     nonisolated let stream: AsyncThrowingStream<Element, Error>
-    private let onTermination: () -> Void
+    private let onTermination: @Sendable () -> Void
 
     init(
         stream: AsyncThrowingStream<Element, Error>,
-        onTermination: @escaping () -> Void
+        onTermination: @escaping @Sendable () -> Void
     ) {
         self.stream = stream
         self.onTermination = onTermination
     }
 
-    nonisolated func makeAsyncIterator() -> AsyncIterator {
-        stream.makeAsyncIterator()
+    nonisolated func makeAsyncIterator() -> Iterator {
+        Iterator(
+            iterator: stream.makeAsyncIterator(),
+            onTermination: onTermination
+        )
     }
 
     isolated deinit {
         onTermination()
+    }
+
+    final class Iterator: AsyncIteratorProtocol {
+        private var iterator: AsyncThrowingStream<PlayerEngine.Event, Error>.AsyncIterator
+        private var onTermination: (@Sendable () -> Void)?
+
+        init(
+            iterator: AsyncThrowingStream<PlayerEngine.Event, Error>.AsyncIterator,
+            onTermination: @escaping @Sendable () -> Void
+        ) {
+            self.iterator = iterator
+            self.onTermination = onTermination
+        }
+
+        func next() async throws -> PlayerEngine.Event? {
+            var localIterator = iterator
+            defer { iterator = localIterator }
+            return try await localIterator.next()
+        }
+
+        deinit {
+            onTermination?()
+            onTermination = nil
+        }
     }
 }
 

--- a/Sources/PDVideoPlayer/Common/Player/ViewModel/PlayerEngine.swift
+++ b/Sources/PDVideoPlayer/Common/Player/ViewModel/PlayerEngine.swift
@@ -1,6 +1,5 @@
 import Foundation
 import AVFoundation
-import Combine
 
 @MainActor
 final class PlayerEngine {
@@ -10,12 +9,17 @@ final class PlayerEngine {
         case itemReady
     }
 
+    enum StreamError: Error {
+        case itemFailed(underlying: Error?)
+    }
+
     private(set) var player: AVPlayer
 
-    private var cancellables = Set<AnyCancellable>()
-    private var itemStatusCancellable: AnyCancellable?
     private var timeTask: Task<Void, Never>?
-    private var eventContinuation: AsyncStream<Event>.Continuation?
+    private var statusTask: Task<Void, Never>?
+    private var currentItemTask: Task<Void, Never>?
+    private var eventContinuation: AsyncThrowingStream<Event, Error>.Continuation?
+    private var currentStreamID: UUID?
     private let observer: PlayerEngineObserving
 
     init(player: AVPlayer, observer: PlayerEngineObserving = PlayerEngineObserver()) {
@@ -29,69 +33,158 @@ final class PlayerEngine {
         player = newPlayer
     }
 
-    func startObserving() -> AsyncStream<Event> {
-        stopObserving()
+    func startObserving() -> PlayerEventStream {
+        stopObserving(finishStream: true)
         player.appliesMediaSelectionCriteriaAutomatically = false
 
-        let stream = AsyncStream<Event> { continuation in
+        let streamID = UUID()
+        currentStreamID = streamID
+        let stream = AsyncThrowingStream<Event, Error> { continuation in
             eventContinuation = continuation
-            continuation.onTermination = { [weak self] _ in
-                Task { @MainActor [weak self] in
-                    self?.stopObserving()
-                }
-            }
         }
 
         let (initialTime, initialDuration) = observer.initialTime(for: player)
-        yieldEvent(.time(current: initialTime.isFinite ? initialTime : 0, duration: initialDuration))
+        yieldEvent(.time(current: initialTime.isFinite ? initialTime : 0, duration: initialDuration), streamID: streamID)
 
-        observer.timeControlStatusPublisher(for: player)
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] status in
-                guard let self else { return }
-                self.yieldEvent(.status(status, self.observer.waitingReason(for: self.player)))
-            }
-            .store(in: &cancellables)
+        startObservationTasks(streamID: streamID)
 
-        observer.currentItemPublisher(for: player)
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] item in
-                guard let self else { return }
-                self.itemStatusCancellable?.cancel()
-                self.itemStatusCancellable = nil
-                guard let item else { return }
-                self.itemStatusCancellable = self.observer.itemStatusPublisher(for: item)
-                    .receive(on: DispatchQueue.main)
-                    .sink { status in
-                        if status == .readyToPlay {
-                            self.yieldEvent(.itemReady)
-                        }
-                    }
-            }
-            .store(in: &cancellables)
-
-        let timeStream = observer.timeStream(for: player)
-        timeTask = Task { [weak self] in
-            for await time in timeStream {
-                guard let self else { return }
-                if Task.isCancelled { break }
-                let current = CMTimeGetSeconds(time)
-                let duration = currentDurationSeconds()
-                self.yieldEvent(.time(current: current.isFinite ? current : 0, duration: duration))
-            }
+        return PlayerEventStream(stream: stream) { [weak self] in
+            self?.invalidateStreamIfCurrent(streamID: streamID)
         }
-
-        return stream
     }
 
     func stopObserving() {
+        stopObserving(finishStream: true)
+    }
+
+    private func stopObserving(finishStream: Bool) {
+        cancelObservationTasks()
+        if finishStream {
+            eventContinuation?.finish()
+        }
+        eventContinuation = nil
+        currentStreamID = nil
+    }
+
+    private func cancelObservationTasks() {
         timeTask?.cancel()
         timeTask = nil
-        itemStatusCancellable?.cancel()
-        itemStatusCancellable = nil
-        cancellables.removeAll()
-        eventContinuation?.finish()
+        statusTask?.cancel()
+        statusTask = nil
+        currentItemTask?.cancel()
+        currentItemTask = nil
+    }
+
+    private func invalidateStreamIfCurrent(streamID: UUID) {
+        guard currentStreamID == streamID else { return }
+        cancelObservationTasks()
         eventContinuation = nil
+        currentStreamID = nil
+    }
+
+    private func startObservationTasks(streamID: UUID) {
+        timeTask?.cancel()
+        statusTask?.cancel()
+        currentItemTask?.cancel()
+
+        let timeStream = observer.timeStream(for: player)
+        let statusStream = observer.timeControlStatusStream(for: player)
+        let itemStream = observer.currentItemStream(for: player)
+
+        timeTask = Task { @MainActor [weak self] in
+            await self?.observeTime(stream: timeStream, streamID: streamID)
+        }
+
+        statusTask = Task { @MainActor [weak self] in
+            await self?.observeStatus(stream: statusStream, streamID: streamID)
+        }
+
+        currentItemTask = Task { @MainActor [weak self] in
+            await self?.observeCurrentItem(stream: itemStream, streamID: streamID)
+        }
+    }
+
+    private func observeTime(stream: AnyAsyncSequence<CMTime>, streamID: UUID) async {
+        let timeStream = stream
+        do {
+            for try await time in timeStream {
+                guard !Task.isCancelled else { break }
+                let current = CMTimeGetSeconds(time)
+                let duration = currentDurationSeconds()
+                yieldEvent(.time(current: current.isFinite ? current : 0, duration: duration), streamID: streamID)
+            }
+        } catch {
+            return
+        }
+    }
+
+    private func observeStatus(stream: AnyAsyncSequence<AVPlayer.TimeControlStatus>, streamID: UUID) async {
+        let statusStream = stream
+        do {
+            for try await status in statusStream {
+                guard !Task.isCancelled else { break }
+                yieldEvent(.status(status, observer.waitingReason(for: player)), streamID: streamID)
+            }
+        } catch {
+            return
+        }
+    }
+
+    private func observeCurrentItem(stream: AnyAsyncSequence<Void>, streamID: UUID) async {
+        let itemStream = stream
+        var itemTask: Task<Void, Never>?
+        var didReceiveInitialItem = false
+        defer { itemTask?.cancel() }
+
+        do {
+            for try await _ in itemStream {
+                guard !Task.isCancelled else { break }
+                itemTask?.cancel()
+                itemTask = nil
+
+                if didReceiveInitialItem {
+                    let (initialTime, initialDuration) = observer.initialTime(for: player)
+                    yieldEvent(.time(current: initialTime.isFinite ? initialTime : 0, duration: initialDuration), streamID: streamID)
+                } else {
+                    didReceiveInitialItem = true
+                }
+
+                guard let item = player.currentItem else { continue }
+                itemTask = Task { @MainActor [weak self] in
+                    await self?.observeItemStatus(for: item, streamID: streamID)
+                }
+            }
+        } catch {
+            return
+        }
+    }
+
+    private func observeItemStatus(for item: AVPlayerItem, streamID: UUID) async {
+        let statusStream = observer.itemStatusStream(for: item)
+        do {
+            for try await status in statusStream {
+                guard !Task.isCancelled else { break }
+                switch status {
+                case .readyToPlay:
+                    yieldEvent(.itemReady, streamID: streamID)
+                case .failed:
+                    finishStream(throwing: StreamError.itemFailed(underlying: item.error), streamID: streamID)
+                    return
+                default:
+                    break
+                }
+            }
+        } catch {
+            return
+        }
+    }
+
+    private func finishStream(throwing error: Error, streamID: UUID) {
+        guard currentStreamID == streamID else { return }
+        cancelObservationTasks()
+        eventContinuation?.finish(throwing: error)
+        eventContinuation = nil
+        currentStreamID = nil
     }
 
     private func currentDurationSeconds() -> Double {
@@ -100,7 +193,8 @@ final class PlayerEngine {
         return total.isFinite ? total : 0
     }
 
-    private func yieldEvent(_ event: Event) {
+    private func yieldEvent(_ event: Event, streamID: UUID) {
+        guard currentStreamID == streamID else { return }
         eventContinuation?.yield(event)
     }
 
@@ -109,76 +203,201 @@ final class PlayerEngine {
     }
 }
 
+@MainActor
+final class PlayerEventStream: AsyncSequence {
+    typealias Element = PlayerEngine.Event
+    typealias AsyncIterator = AsyncThrowingStream<Element, Error>.AsyncIterator
+
+    nonisolated let stream: AsyncThrowingStream<Element, Error>
+    private let onTermination: () -> Void
+
+    init(
+        stream: AsyncThrowingStream<Element, Error>,
+        onTermination: @escaping () -> Void
+    ) {
+        self.stream = stream
+        self.onTermination = onTermination
+    }
+
+    nonisolated func makeAsyncIterator() -> AsyncIterator {
+        stream.makeAsyncIterator()
+    }
+
+    isolated deinit {
+        onTermination()
+    }
+}
+
+struct AnyAsyncSequence<Element>: AsyncSequence {
+    typealias AsyncIterator = AnyAsyncIterator<Element>
+
+    private let _makeIterator: () -> AnyAsyncIterator<Element>
+
+    init<S: AsyncSequence>(_ sequence: S) where S.Element == Element {
+        _makeIterator = {
+            var iterator = sequence.makeAsyncIterator()
+            return AnyAsyncIterator {
+                try await iterator.next()
+            }
+        }
+    }
+
+    func makeAsyncIterator() -> AnyAsyncIterator<Element> {
+        _makeIterator()
+    }
+}
+
+struct AnyAsyncIterator<Element>: AsyncIteratorProtocol {
+    private let _next: () async throws -> Element?
+
+    init(_ next: @escaping () async throws -> Element?) {
+        _next = next
+    }
+
+    mutating func next() async throws -> Element? {
+        try await _next()
+    }
+}
+
+private final class KVOAsyncSequence<Object: NSObject, Value: Sendable>: AsyncSequence {
+    typealias Element = Value
+
+    private let stream: AsyncStream<Value>
+    private let continuation: AsyncStream<Value>.Continuation
+    private var observation: NSKeyValueObservation?
+
+    init(
+        object: Object,
+        keyPath: KeyPath<Object, Value>,
+        options: NSKeyValueObservingOptions = [.new, .initial],
+        bufferingPolicy: AsyncStream<Value>.Continuation.BufferingPolicy = .bufferingNewest(1)
+    ) {
+        (stream, continuation) = AsyncStream.makeStream(bufferingPolicy: bufferingPolicy)
+        let continuation = continuation
+        observation = object.observe(keyPath, options: options) { _, change in
+            guard let value = change.newValue else { return }
+            continuation.yield(value)
+        }
+    }
+
+    func makeAsyncIterator() -> AsyncStream<Value>.Iterator {
+        stream.makeAsyncIterator()
+    }
+
+    deinit {
+        observation?.invalidate()
+        continuation.finish()
+    }
+}
+
+private final class KVOChangeSignalSequence<Object: NSObject, Value>: AsyncSequence {
+    typealias Element = Void
+
+    private let stream: AsyncStream<Void>
+    private let continuation: AsyncStream<Void>.Continuation
+    private var observation: NSKeyValueObservation?
+
+    init(
+        object: Object,
+        keyPath: KeyPath<Object, Value?>,
+        options: NSKeyValueObservingOptions = [.new, .initial]
+    ) {
+        (stream, continuation) = AsyncStream.makeStream(bufferingPolicy: .bufferingNewest(1))
+        let continuation = continuation
+        observation = object.observe(keyPath, options: options) { _, _ in
+            continuation.yield(())
+        }
+    }
+
+    func makeAsyncIterator() -> AsyncStream<Void>.Iterator {
+        stream.makeAsyncIterator()
+    }
+
+    deinit {
+        observation?.invalidate()
+        continuation.finish()
+    }
+}
+
+private final class PeriodicTimeSequence: AsyncSequence {
+    typealias Element = CMTime
+
+    private let stream: AsyncStream<CMTime>
+    private let continuation: AsyncStream<CMTime>.Continuation
+    private weak var player: AVPlayer?
+    private var token: Any?
+
+    init(
+        player: AVPlayer,
+        interval: CMTime,
+        queue: DispatchQueue
+    ) {
+        self.player = player
+        (stream, continuation) = AsyncStream.makeStream(bufferingPolicy: .bufferingNewest(1))
+        let continuation = continuation
+        token = player.addPeriodicTimeObserver(forInterval: interval, queue: queue) { time in
+            continuation.yield(time)
+        }
+    }
+
+    func makeAsyncIterator() -> AsyncStream<CMTime>.Iterator {
+        stream.makeAsyncIterator()
+    }
+
+    deinit {
+        continuation.finish()
+        if let player, let token {
+            player.removeTimeObserver(token)
+        }
+    }
+}
+
 protocol PlayerEngineObserving {
-    func initialTime(for player: AVPlayer) -> (Double, Double)
-    @MainActor func timeStream(for player: AVPlayer) -> AsyncStream<CMTime>
-    func timeControlStatusPublisher(for player: AVPlayer) -> AnyPublisher<AVPlayer.TimeControlStatus, Never>
-    func currentItemPublisher(for player: AVPlayer) -> AnyPublisher<AVPlayerItem?, Never>
-    func itemStatusPublisher(for item: AVPlayerItem) -> AnyPublisher<AVPlayerItem.Status, Never>
-    func waitingReason(for player: AVPlayer) -> AVPlayer.WaitingReason?
+    @MainActor func initialTime(for player: AVPlayer) -> (Double, Double)
+    @MainActor func timeStream(for player: AVPlayer) -> AnyAsyncSequence<CMTime>
+    @MainActor func timeControlStatusStream(for player: AVPlayer) -> AnyAsyncSequence<AVPlayer.TimeControlStatus>
+    @MainActor func currentItemStream(for player: AVPlayer) -> AnyAsyncSequence<Void>
+    @MainActor func itemStatusStream(for item: AVPlayerItem) -> AnyAsyncSequence<AVPlayerItem.Status>
+    @MainActor func waitingReason(for player: AVPlayer) -> AVPlayer.WaitingReason?
 }
 
 struct PlayerEngineObserver: PlayerEngineObserving {
-    func initialTime(for player: AVPlayer) -> (Double, Double) {
+    @MainActor func initialTime(for player: AVPlayer) -> (Double, Double) {
         let initialDuration = currentDurationSeconds(for: player)
         let initialTime = CMTimeGetSeconds(player.currentTime())
         return (initialTime.isFinite ? initialTime : 0, initialDuration)
     }
 
-    @MainActor func timeStream(for player: AVPlayer) -> AsyncStream<CMTime> {
-        player.periodicTimeStream(
-            forInterval: CMTime(value: 1, timescale: 30),
-            queue: .main
+    @MainActor func timeStream(for player: AVPlayer) -> AnyAsyncSequence<CMTime> {
+        AnyAsyncSequence(
+            PeriodicTimeSequence(
+                player: player,
+                interval: CMTime(value: 1, timescale: 30),
+                queue: .main
+            )
         )
     }
 
-    func timeControlStatusPublisher(for player: AVPlayer) -> AnyPublisher<AVPlayer.TimeControlStatus, Never> {
-        player.publisher(for: \.timeControlStatus)
-            .eraseToAnyPublisher()
+    @MainActor func timeControlStatusStream(for player: AVPlayer) -> AnyAsyncSequence<AVPlayer.TimeControlStatus> {
+        AnyAsyncSequence(KVOAsyncSequence(object: player, keyPath: \.timeControlStatus))
     }
 
-    func currentItemPublisher(for player: AVPlayer) -> AnyPublisher<AVPlayerItem?, Never> {
-        player.publisher(for: \.currentItem, options: [.new, .initial])
-            .eraseToAnyPublisher()
+    @MainActor func currentItemStream(for player: AVPlayer) -> AnyAsyncSequence<Void> {
+        AnyAsyncSequence(KVOChangeSignalSequence(object: player, keyPath: \.currentItem))
     }
 
-    func itemStatusPublisher(for item: AVPlayerItem) -> AnyPublisher<AVPlayerItem.Status, Never> {
-        item.publisher(for: \.status, options: [.new, .initial])
-            .eraseToAnyPublisher()
+    @MainActor func itemStatusStream(for item: AVPlayerItem) -> AnyAsyncSequence<AVPlayerItem.Status> {
+        AnyAsyncSequence(KVOAsyncSequence(object: item, keyPath: \.status, options: [.new, .initial]))
     }
 
-    func waitingReason(for player: AVPlayer) -> AVPlayer.WaitingReason? {
+    @MainActor func waitingReason(for player: AVPlayer) -> AVPlayer.WaitingReason? {
         player.reasonForWaitingToPlay
     }
 
+    @MainActor
     private func currentDurationSeconds(for player: AVPlayer) -> Double {
         guard let item = player.currentItem else { return 0 }
         let total = CMTimeGetSeconds(item.duration)
         return total.isFinite ? total : 0
-    }
-}
-
-public extension AVPlayer {
-    func periodicTimeStream(
-        forInterval interval: CMTime,
-        queue: DispatchQueue
-    ) -> AsyncStream<CMTime> {
-        AsyncStream { continuation in
-            let rawToken = addPeriodicTimeObserver(
-                forInterval: interval,
-                queue: queue
-            ) { time in
-                continuation.yield(time)
-            }
-
-            struct TokenBox: @unchecked Sendable {
-                let token: Any
-            }
-            let box = TokenBox(token: rawToken)
-
-            continuation.onTermination = { _ in
-                self.removeTimeObserver(box.token)
-            }
-        }
     }
 }

--- a/Sources/PDVideoPlayer/Common/Player/ViewModel/PlayerEngine.swift
+++ b/Sources/PDVideoPlayer/Common/Player/ViewModel/PlayerEngine.swift
@@ -168,7 +168,6 @@ final class PlayerEngine {
                     yieldEvent(.itemReady, streamID: streamID)
                 case .failed:
                     yieldEvent(.itemFailed(underlying: item.error), streamID: streamID)
-                    return
                 default:
                     break
                 }

--- a/Sources/PDVideoPlayer/Common/Player/ViewModel/PlayerViewModel.swift
+++ b/Sources/PDVideoPlayer/Common/Player/ViewModel/PlayerViewModel.swift
@@ -104,54 +104,46 @@ public final class PlayerViewModel {
         let stream = engine.startObserving()
         observeTask = Task { @MainActor [weak self] in
             guard let self else { return }
-            do {
-                for try await event in stream {
-                    switch event {
-                    case .time(let current, let duration):
-                        currentTime = current
-                        self.duration = duration
-                    case .status(let status, let waitingReason):
-                        switch status {
-                        case .playing:
-                            if !isPlaying { isPlaying = true }
+            for await event in stream {
+                switch event {
+                case .time(let current, let duration):
+                    currentTime = current
+                    self.duration = duration
+                case .status(let status, let waitingReason):
+                    switch status {
+                    case .playing:
+                        if !isPlaying { isPlaying = true }
 #if os(iOS)
-                            if isLongpress {
-                                let fastRate = min(originalRate * 2.0, 2.0)
-                                if player.rate != fastRate {
-                                    player.rate = fastRate
-                                }
+                        if isLongpress {
+                            let fastRate = min(originalRate * 2.0, 2.0)
+                            if player.rate != fastRate {
+                                player.rate = fastRate
                             }
-#endif
-                            if isBuffering { isBuffering = false }
-                        case .paused:
-                            if isPlaying, !isTracking { isPlaying = false }
-                            if isBuffering { isBuffering = false }
-                        case .waitingToPlayAtSpecifiedRate:
-                            switch waitingReason {
-                            case .evaluatingBufferingRate, .toMinimizeStalls:
-                                if !isBuffering { isBuffering = true }
-                            default:
-                                if isBuffering { isBuffering = false }
-                            }
-                        @unknown default:
-                            break
                         }
-                    case .itemReady:
-                        Task { await loadSubtitleOptions() }
-                    case .itemFailed(let error):
+#endif
                         if isBuffering { isBuffering = false }
+                    case .paused:
                         if isPlaying, !isTracking { isPlaying = false }
-#if DEBUG
-                        print("⚠️ player item failed:", error as Any)
-#endif
+                        if isBuffering { isBuffering = false }
+                    case .waitingToPlayAtSpecifiedRate:
+                        switch waitingReason {
+                        case .evaluatingBufferingRate, .toMinimizeStalls:
+                            if !isBuffering { isBuffering = true }
+                        default:
+                            if isBuffering { isBuffering = false }
+                        }
+                    @unknown default:
+                        break
                     }
-                }
-            } catch {
-                if isBuffering { isBuffering = false }
-                if isPlaying, !isTracking { isPlaying = false }
+                case .itemReady:
+                    Task { await loadSubtitleOptions() }
+                case .itemFailed(let error):
+                    if isBuffering { isBuffering = false }
+                    if isPlaying, !isTracking { isPlaying = false }
 #if DEBUG
-                print("⚠️ player observation failed:", error)
+                    print("⚠️ player item failed:", error as Any)
 #endif
+                }
             }
         }
     }

--- a/Sources/PDVideoPlayer/Common/Player/ViewModel/PlayerViewModel.swift
+++ b/Sources/PDVideoPlayer/Common/Player/ViewModel/PlayerViewModel.swift
@@ -138,6 +138,12 @@ public final class PlayerViewModel {
                         }
                     case .itemReady:
                         Task { await loadSubtitleOptions() }
+                    case .itemFailed(let error):
+                        if isBuffering { isBuffering = false }
+                        if isPlaying, !isTracking { isPlaying = false }
+#if DEBUG
+                        print("⚠️ player item failed:", error as Any)
+#endif
                     }
                 }
             } catch {

--- a/Sources/PDVideoPlayer/Common/Player/ViewModel/PlayerViewModel.swift
+++ b/Sources/PDVideoPlayer/Common/Player/ViewModel/PlayerViewModel.swift
@@ -168,7 +168,9 @@ public final class PlayerViewModel {
     }
 
     public func togglePlay() {
-        if player.timeControlStatus == .playing || player.rate != 0 {
+        if player.timeControlStatus == .playing ||
+            player.timeControlStatus == .waitingToPlayAtSpecifiedRate ||
+            player.rate != 0 {
             pause()
         } else {
             play()

--- a/Sources/PDVideoPlayer/Common/Player/ViewModel/PlayerViewModel.swift
+++ b/Sources/PDVideoPlayer/Common/Player/ViewModel/PlayerViewModel.swift
@@ -159,7 +159,7 @@ public final class PlayerViewModel {
         }
         player.play()
         player.rate = playbackSpeed.value
-        if !isTracking { isPlaying = true }
+        if !isTracking, player.currentItem != nil { isPlaying = true }
     }
 
     func pause() {

--- a/Sources/PDVideoPlayer/Common/Player/ViewModel/PlayerViewModel.swift
+++ b/Sources/PDVideoPlayer/Common/Player/ViewModel/PlayerViewModel.swift
@@ -2,7 +2,7 @@
 import AppKit
 #endif
 import SwiftUI
-@preconcurrency import AVFoundation
+import AVFoundation
 
 #if os(iOS)
 enum SkipDirection {
@@ -104,40 +104,48 @@ public final class PlayerViewModel {
         let stream = engine.startObserving()
         observeTask = Task { @MainActor [weak self] in
             guard let self else { return }
-            for await event in stream {
-                switch event {
-                case .time(let current, let duration):
-                    currentTime = current
-                    self.duration = duration
-                case .status(let status, let waitingReason):
-                    switch status {
-                    case .playing:
-                        if !isPlaying { isPlaying = true }
+            do {
+                for try await event in stream {
+                    switch event {
+                    case .time(let current, let duration):
+                        currentTime = current
+                        self.duration = duration
+                    case .status(let status, let waitingReason):
+                        switch status {
+                        case .playing:
+                            if !isPlaying { isPlaying = true }
 #if os(iOS)
-                        if isLongpress {
-                            let fastRate = min(originalRate * 2.0, 2.0)
-                            if player.rate != fastRate {
-                                player.rate = fastRate
+                            if isLongpress {
+                                let fastRate = min(originalRate * 2.0, 2.0)
+                                if player.rate != fastRate {
+                                    player.rate = fastRate
+                                }
                             }
-                        }
 #endif
-                        if isBuffering { isBuffering = false }
-                    case .paused:
-                        if isPlaying, !isTracking { isPlaying = false }
-                        if isBuffering { isBuffering = false }
-                    case .waitingToPlayAtSpecifiedRate:
-                        switch waitingReason {
-                        case .evaluatingBufferingRate, .toMinimizeStalls:
-                            if !isBuffering { isBuffering = true }
-                        default:
                             if isBuffering { isBuffering = false }
+                        case .paused:
+                            if isPlaying, !isTracking { isPlaying = false }
+                            if isBuffering { isBuffering = false }
+                        case .waitingToPlayAtSpecifiedRate:
+                            switch waitingReason {
+                            case .evaluatingBufferingRate, .toMinimizeStalls:
+                                if !isBuffering { isBuffering = true }
+                            default:
+                                if isBuffering { isBuffering = false }
+                            }
+                        @unknown default:
+                            break
                         }
-                    @unknown default:
-                        break
+                    case .itemReady:
+                        Task { await loadSubtitleOptions() }
                     }
-                case .itemReady:
-                    Task { await loadSubtitleOptions() }
                 }
+            } catch {
+                if isBuffering { isBuffering = false }
+                if isPlaying, !isTracking { isPlaying = false }
+#if DEBUG
+                print("⚠️ player observation failed:", error)
+#endif
             }
         }
     }
@@ -153,12 +161,20 @@ public final class PlayerViewModel {
         }
         player.play()
         player.rate = playbackSpeed.value
+        if !isTracking { isPlaying = true }
     }
 
-    func pause() { player.pause() }
+    func pause() {
+        player.pause()
+        if !isTracking { isPlaying = false }
+    }
 
     public func togglePlay() {
-        isPlaying ? pause() : play()
+        if player.timeControlStatus == .playing || player.rate != 0 {
+            pause()
+        } else {
+            play()
+        }
     }
 
     public func seekRatio(_ ratio: Double) {

--- a/Tests/PDVideoPlayerTests/PDVideoPlayerTests.swift
+++ b/Tests/PDVideoPlayerTests/PDVideoPlayerTests.swift
@@ -293,13 +293,11 @@ import Testing
     var timeEvents: [(Double, Double)] = []
     let stream = engine.startObserving()
     let task = Task {
-        do {
-            for try await event in stream {
-                if case .time(let time, let duration) = event {
-                    timeEvents.append((time, duration))
-                }
+        for await event in stream {
+            if case .time(let time, let duration) = event {
+                timeEvents.append((time, duration))
             }
-        } catch { }
+        }
     }
     defer {
         engine.stopObserving()
@@ -329,13 +327,11 @@ import Testing
     var statusEvents: [AVPlayer.TimeControlStatus] = []
     let stream = engine.startObserving()
     let task = Task {
-        do {
-            for try await event in stream {
-                if case .status(let status, _) = event {
-                    statusEvents.append(status)
-                }
+        for await event in stream {
+            if case .status(let status, _) = event {
+                statusEvents.append(status)
             }
-        } catch { }
+        }
     }
     defer {
         engine.stopObserving()
@@ -357,13 +353,11 @@ import Testing
     var readyCount = 0
     let stream = engine.startObserving()
     let task = Task {
-        do {
-            for try await event in stream {
-                if case .itemReady = event {
-                    readyCount += 1
-                }
+        for await event in stream {
+            if case .itemReady = event {
+                readyCount += 1
             }
-        } catch { }
+        }
     }
     defer {
         engine.stopObserving()
@@ -392,13 +386,11 @@ import Testing
     var statusEvents: [AVPlayer.TimeControlStatus] = []
     let stream = engine.startObserving()
     let task = Task {
-        do {
-            for try await event in stream {
-                if case .status(let status, _) = event {
-                    statusEvents.append(status)
-                }
+        for await event in stream {
+            if case .status(let status, _) = event {
+                statusEvents.append(status)
             }
-        } catch { }
+        }
     }
     defer { task.cancel() }
 
@@ -418,15 +410,15 @@ import Testing
     var timeEvents: [(Double, Double)] = []
     let stream = engine.startObserving()
     let task = Task {
-        do {
-            for try await event in stream {
-                if case .time(let time, let duration) = event {
-                    timeEvents.append((time, duration))
-                }
+        for await event in stream {
+            if case .time(let time, let duration) = event {
+                timeEvents.append((time, duration))
             }
-        } catch { }
+        }
     }
-    defer { task.cancel() }
+    defer {
+        task.cancel()
+    }
 
     let didSeed = await waitUntil(timeout: .milliseconds(200)) { timeEvents.count == 1 }
     #expect(didSeed == true)
@@ -439,6 +431,60 @@ import Testing
     #expect(didReceive == false)
 
     #expect(timeEvents.count == 1)
+}
+
+@MainActor
+@Test func playerEngineEmitsItemFailedAndContinues() async throws {
+    let observer = TestPlayerEngineObserver()
+    let engine = PlayerEngine(player: AVPlayer(), observer: observer)
+
+    var failedCount = 0
+    var readyCount = 0
+    let stream = engine.startObserving()
+    let task = Task {
+        for await event in stream {
+            switch event {
+            case .itemFailed:
+                failedCount += 1
+            case .itemReady:
+                readyCount += 1
+            default:
+                break
+            }
+        }
+    }
+    defer {
+        engine.stopObserving()
+        task.cancel()
+    }
+
+    let item = AVPlayerItem(asset: AVMutableComposition())
+    engine.player.replaceCurrentItem(with: item)
+    observer.currentItemContinuation?.yield(())
+    let didSubscribe = await waitUntil(timeout: .milliseconds(200)) {
+        observer.didRequestItemStatusStream
+    }
+    #expect(didSubscribe == true)
+
+    observer.itemStatusContinuation?.yield(.failed)
+    let didFail = await waitUntil(timeout: .milliseconds(200)) { failedCount == 1 }
+    #expect(didFail == true)
+
+    observer.didRequestItemStatusStream = false
+    let nextItem = AVPlayerItem(asset: AVMutableComposition())
+    engine.player.replaceCurrentItem(with: nextItem)
+    observer.currentItemContinuation?.yield(())
+    let didResubscribe = await waitUntil(timeout: .milliseconds(200)) {
+        observer.didRequestItemStatusStream
+    }
+    #expect(didResubscribe == true)
+
+    observer.itemStatusContinuation?.yield(.readyToPlay)
+    let didReady = await waitUntil(timeout: .milliseconds(200)) { readyCount == 1 }
+    #expect(didReady == true)
+
+    #expect(failedCount == 1)
+    #expect(readyCount == 1)
 }
 
 final class TestPlayerEngineObserver: PlayerEngineObserving {

--- a/Tests/PDVideoPlayerTests/PDVideoPlayerTests.swift
+++ b/Tests/PDVideoPlayerTests/PDVideoPlayerTests.swift
@@ -465,10 +465,16 @@ import Testing
         observer.didRequestItemStatusStream
     }
     #expect(didSubscribe == true)
+    let initialRequestCount = observer.itemStatusStreamRequestCount
 
     observer.itemStatusContinuation?.yield(.failed)
     let didFail = await waitUntil(timeout: .milliseconds(200)) { failedCount == 1 }
     #expect(didFail == true)
+
+    observer.itemStatusContinuation?.yield(.readyToPlay)
+    let didRecoverSameItem = await waitUntil(timeout: .milliseconds(200)) { readyCount == 1 }
+    #expect(didRecoverSameItem == true)
+    #expect(observer.itemStatusStreamRequestCount == initialRequestCount)
 
     observer.didRequestItemStatusStream = false
     let nextItem = AVPlayerItem(asset: AVMutableComposition())
@@ -478,19 +484,21 @@ import Testing
         observer.didRequestItemStatusStream
     }
     #expect(didResubscribe == true)
+    #expect(observer.itemStatusStreamRequestCount == initialRequestCount + 1)
 
     observer.itemStatusContinuation?.yield(.readyToPlay)
-    let didReady = await waitUntil(timeout: .milliseconds(200)) { readyCount == 1 }
+    let didReady = await waitUntil(timeout: .milliseconds(200)) { readyCount == 2 }
     #expect(didReady == true)
 
     #expect(failedCount == 1)
-    #expect(readyCount == 1)
+    #expect(readyCount == 2)
 }
 
 final class TestPlayerEngineObserver: PlayerEngineObserving {
     var initialTime: (Double, Double) = (0, 0)
     var waitingReason: AVPlayer.WaitingReason?
     var didRequestItemStatusStream = false
+    var itemStatusStreamRequestCount = 0
     var timeContinuation: AsyncStream<CMTime>.Continuation?
     var statusContinuation: AsyncStream<AVPlayer.TimeControlStatus>.Continuation?
     var currentItemContinuation: AsyncStream<Void>.Continuation?
@@ -518,6 +526,7 @@ final class TestPlayerEngineObserver: PlayerEngineObserving {
 
     @MainActor func itemStatusStream(for item: AVPlayerItem) -> AnyAsyncSequence<AVPlayerItem.Status> {
         didRequestItemStatusStream = true
+        itemStatusStreamRequestCount += 1
         return AnyAsyncSequence(AsyncStream { continuation in
             itemStatusContinuation = continuation
         })

--- a/Tests/PDVideoPlayerTests/PDVideoPlayerTests.swift
+++ b/Tests/PDVideoPlayerTests/PDVideoPlayerTests.swift
@@ -1,5 +1,4 @@
 import AVFoundation
-import Combine
 import Testing
 @testable import PDVideoPlayer
 
@@ -65,11 +64,11 @@ import Testing
     let model = PlayerViewModel(player: AVPlayer(), observer: observer)
     model.startObserving()
 
-    observer.statusSubject.send(.playing)
+    observer.statusContinuation?.yield(.playing)
     let didPlay = await waitUntil { model.isPlaying }
     #expect(didPlay == true)
 
-    observer.statusSubject.send(.paused)
+    observer.statusContinuation?.yield(.paused)
     let didPause = await waitUntil { model.isPlaying == false }
     #expect(didPause == true)
 }
@@ -81,12 +80,12 @@ import Testing
     model.startObserving()
 
     observer.waitingReason = .toMinimizeStalls
-    observer.statusSubject.send(.waitingToPlayAtSpecifiedRate)
+    observer.statusContinuation?.yield(.waitingToPlayAtSpecifiedRate)
     let didBuffer = await waitUntil { model.isBuffering }
     #expect(didBuffer == true)
 
     observer.waitingReason = nil
-    observer.statusSubject.send(.waitingToPlayAtSpecifiedRate)
+    observer.statusContinuation?.yield(.waitingToPlayAtSpecifiedRate)
     let didClear = await waitUntil { model.isBuffering == false }
     #expect(didClear == true)
 }
@@ -294,11 +293,13 @@ import Testing
     var timeEvents: [(Double, Double)] = []
     let stream = engine.startObserving()
     let task = Task {
-        for await event in stream {
-            if case .time(let time, let duration) = event {
-                timeEvents.append((time, duration))
+        do {
+            for try await event in stream {
+                if case .time(let time, let duration) = event {
+                    timeEvents.append((time, duration))
+                }
             }
-        }
+        } catch { }
     }
     defer {
         engine.stopObserving()
@@ -328,18 +329,20 @@ import Testing
     var statusEvents: [AVPlayer.TimeControlStatus] = []
     let stream = engine.startObserving()
     let task = Task {
-        for await event in stream {
-            if case .status(let status, _) = event {
-                statusEvents.append(status)
+        do {
+            for try await event in stream {
+                if case .status(let status, _) = event {
+                    statusEvents.append(status)
+                }
             }
-        }
+        } catch { }
     }
     defer {
         engine.stopObserving()
         task.cancel()
     }
 
-    observer.statusSubject.send(.paused)
+    observer.statusContinuation?.yield(.paused)
     let didReceive = await waitUntil(timeout: .milliseconds(200)) { statusEvents == [.paused] }
     #expect(didReceive == true)
 
@@ -354,11 +357,13 @@ import Testing
     var readyCount = 0
     let stream = engine.startObserving()
     let task = Task {
-        for await event in stream {
-            if case .itemReady = event {
-                readyCount += 1
+        do {
+            for try await event in stream {
+                if case .itemReady = event {
+                    readyCount += 1
+                }
             }
-        }
+        } catch { }
     }
     defer {
         engine.stopObserving()
@@ -366,12 +371,13 @@ import Testing
     }
 
     let item = AVPlayerItem(asset: AVMutableComposition())
-    observer.currentItemSubject.send(item)
+    engine.player.replaceCurrentItem(with: item)
+    observer.currentItemContinuation?.yield(())
     let didSubscribe = await waitUntil(timeout: .milliseconds(200)) {
-        observer.didRequestItemStatusPublisher
+        observer.didRequestItemStatusStream
     }
     #expect(didSubscribe == true)
-    observer.itemStatusSubject.send(.readyToPlay)
+    observer.itemStatusContinuation?.yield(.readyToPlay)
     let didReady = await waitUntil(timeout: .milliseconds(200)) { readyCount == 1 }
     #expect(didReady == true)
 
@@ -386,16 +392,18 @@ import Testing
     var statusEvents: [AVPlayer.TimeControlStatus] = []
     let stream = engine.startObserving()
     let task = Task {
-        for await event in stream {
-            if case .status(let status, _) = event {
-                statusEvents.append(status)
+        do {
+            for try await event in stream {
+                if case .status(let status, _) = event {
+                    statusEvents.append(status)
+                }
             }
-        }
+        } catch { }
     }
     defer { task.cancel() }
 
     engine.stopObserving()
-    observer.statusSubject.send(.paused)
+    observer.statusContinuation?.yield(.paused)
     let didReceive = await waitUntil(timeout: .milliseconds(200)) { !statusEvents.isEmpty }
     #expect(didReceive == false)
 
@@ -410,11 +418,13 @@ import Testing
     var timeEvents: [(Double, Double)] = []
     let stream = engine.startObserving()
     let task = Task {
-        for await event in stream {
-            if case .time(let time, let duration) = event {
-                timeEvents.append((time, duration))
+        do {
+            for try await event in stream {
+                if case .time(let time, let duration) = event {
+                    timeEvents.append((time, duration))
+                }
             }
-        }
+        } catch { }
     }
     defer { task.cancel() }
 
@@ -433,35 +443,41 @@ import Testing
 
 final class TestPlayerEngineObserver: PlayerEngineObserving {
     var initialTime: (Double, Double) = (0, 0)
-    let statusSubject = PassthroughSubject<AVPlayer.TimeControlStatus, Never>()
-    let currentItemSubject = PassthroughSubject<AVPlayerItem?, Never>()
-    let itemStatusSubject = PassthroughSubject<AVPlayerItem.Status, Never>()
     var waitingReason: AVPlayer.WaitingReason?
-    var didRequestItemStatusPublisher = false
+    var didRequestItemStatusStream = false
     var timeContinuation: AsyncStream<CMTime>.Continuation?
+    var statusContinuation: AsyncStream<AVPlayer.TimeControlStatus>.Continuation?
+    var currentItemContinuation: AsyncStream<Void>.Continuation?
+    var itemStatusContinuation: AsyncStream<AVPlayerItem.Status>.Continuation?
 
-    func initialTime(for player: AVPlayer) -> (Double, Double) { initialTime }
+    @MainActor func initialTime(for player: AVPlayer) -> (Double, Double) { initialTime }
 
-    @MainActor func timeStream(for player: AVPlayer) -> AsyncStream<CMTime> {
-        AsyncStream { continuation in
+    @MainActor func timeStream(for player: AVPlayer) -> AnyAsyncSequence<CMTime> {
+        AnyAsyncSequence(AsyncStream { continuation in
             timeContinuation = continuation
-        }
+        })
     }
 
-    func timeControlStatusPublisher(for player: AVPlayer) -> AnyPublisher<AVPlayer.TimeControlStatus, Never> {
-        statusSubject.eraseToAnyPublisher()
+    @MainActor func timeControlStatusStream(for player: AVPlayer) -> AnyAsyncSequence<AVPlayer.TimeControlStatus> {
+        AnyAsyncSequence(AsyncStream { continuation in
+            statusContinuation = continuation
+        })
     }
 
-    func currentItemPublisher(for player: AVPlayer) -> AnyPublisher<AVPlayerItem?, Never> {
-        currentItemSubject.eraseToAnyPublisher()
+    @MainActor func currentItemStream(for player: AVPlayer) -> AnyAsyncSequence<Void> {
+        AnyAsyncSequence(AsyncStream { continuation in
+            currentItemContinuation = continuation
+        })
     }
 
-    func itemStatusPublisher(for item: AVPlayerItem) -> AnyPublisher<AVPlayerItem.Status, Never> {
-        didRequestItemStatusPublisher = true
-        return itemStatusSubject.eraseToAnyPublisher()
+    @MainActor func itemStatusStream(for item: AVPlayerItem) -> AnyAsyncSequence<AVPlayerItem.Status> {
+        didRequestItemStatusStream = true
+        return AnyAsyncSequence(AsyncStream { continuation in
+            itemStatusContinuation = continuation
+        })
     }
 
-    func waitingReason(for player: AVPlayer) -> AVPlayer.WaitingReason? {
+    @MainActor func waitingReason(for player: AVPlayer) -> AVPlayer.WaitingReason? {
         waitingReason
     }
 }


### PR DESCRIPTION
Summary:
- Refine PlayerEngine observation to async sequences with stream-ID guarded lifecycle cleanup
- Update play/pause/toggle to keep isPlaying in sync with playback state
- Adjust tests to the new async stream observer API

Testing:
- swift test